### PR TITLE
Switch ServiceAccountCredential signing to be FIPS compliant

### DIFF
--- a/Src/GoogleApis.Auth.DotNet4/OAuth2/ServiceAccountCredential.cs
+++ b/Src/GoogleApis.Auth.DotNet4/OAuth2/ServiceAccountCredential.cs
@@ -140,7 +140,10 @@ namespace Google.Apis.Auth.OAuth2
                 .Append(UrlSafeBase64Encode(serializedPayload));
 
             // Sign the header and the payload.
-            var signature = UrlSafeBase64Encode(key.SignData(Encoding.ASCII.GetBytes(assertion.ToString()), "SHA256"));
+            HashAlgorithm hashAlg = new SHA256CryptoServiceProvider();
+            byte[] assertionHash = hashAlg.ComputeHash(Encoding.ASCII.GetBytes(assertion.ToString()));
+
+            var signature = UrlSafeBase64Encode(key.SignHash(assertionHash, "2.16.840.1.101.3.4.2.1" /* SHA256 OIG */)); 
             assertion.Append(".").Append(signature);
 
             // Create the request.

--- a/Src/GoogleApis.Auth.DotNet4/OAuth2/ServiceAccountCredential.cs
+++ b/Src/GoogleApis.Auth.DotNet4/OAuth2/ServiceAccountCredential.cs
@@ -140,7 +140,7 @@ namespace Google.Apis.Auth.OAuth2
                 .Append(UrlSafeBase64Encode(serializedPayload));
 
             // Sign the header and the payload.
-            HashAlgorithm hashAlg = new SHA256CryptoServiceProvider();
+            var hashAlg = new SHA256CryptoServiceProvider();
             byte[] assertionHash = hashAlg.ComputeHash(Encoding.ASCII.GetBytes(assertion.ToString()));
 
             var signature = UrlSafeBase64Encode(key.SignHash(assertionHash, "2.16.840.1.101.3.4.2.1" /* SHA256 OIG */)); 


### PR DESCRIPTION
Adjust JWT signing to be FIPS compliant. 

According to the following article, RsaCryptoServiceProvider's hash mechanism is not FIPS compliant, and exceptions will be thrown on FIPS enabled systems.  This PR performs the hashing and signing in two separate steps -- with the hashing occurring via SHA256CryptoServiceProvider, which makes FIPS happy.

https://connect.microsoft.com/VisualStudio/feedback/details/584754/using-sha256-with-rsacryptoserviceprovider-in-a-webapplication