### PR TITLE
Remove InternalsVisibleTo (Friend assembly) from the codebase

### DIFF
--- a/Src/GoogleApis.Auth/OAuth2/Flows/AuthorizationCodeFlow.cs
+++ b/Src/GoogleApis.Auth/OAuth2/Flows/AuthorizationCodeFlow.cs
@@ -291,7 +291,7 @@ namespace Google.Apis.Auth.OAuth2.Flows
         /// <param name="taskCancellationToken">Cancellation token to cancel operation.</param>
         /// <returns>Token response with the new access token.</returns>
         [VisibleForTestOnly]
-        internal async Task<TokenResponse> FetchTokenAsync(string userId, TokenRequest request,
+        public async Task<TokenResponse> FetchTokenAsync(string userId, TokenRequest request,
             CancellationToken taskCancellationToken)
         {
             // Add client id and client secret to requests.

--- a/Src/GoogleApis.Auth/OAuth2/Requests/TokenRequestExtenstions.cs
+++ b/Src/GoogleApis.Auth/OAuth2/Requests/TokenRequestExtenstions.cs
@@ -26,7 +26,7 @@ using Google.Apis.Util;
 namespace Google.Apis.Auth.OAuth2.Requests
 {
     /// <summary>Extension methods to <see cref="TokenRequest"/>.</summary>
-    internal static class TokenRequestExtenstions
+    public static class TokenRequestExtenstions
     {
         /// <summary>
         /// Executes the token request in order to receive a 

--- a/Src/GoogleApis.Auth/Properties/AssemblyInfo.cs
+++ b/Src/GoogleApis.Auth/Properties/AssemblyInfo.cs
@@ -29,9 +29,6 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyCopyright("Copyright © Google Inc 2013")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
-[assembly: InternalsVisibleTo("Google.Apis.Auth.Tests")]
-[assembly: InternalsVisibleTo("Google.Apis.Auth.PlatformServices")]
-
 
 // The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,

--- a/Src/GoogleApis.Core/Apis/Http/ConfigurableMessageHandler.cs
+++ b/Src/GoogleApis.Core/Apis/Http/ConfigurableMessageHandler.cs
@@ -42,7 +42,7 @@ namespace Google.Apis.Http
 
         /// <summary>Maximum allowed number of tries.</summary>
         [VisibleForTestOnly]
-        internal const int MaxAllowedNumTries = 20;
+        public const int MaxAllowedNumTries = 20;
 
         /// <summary>The current API version of this client library.</summary>
         private static readonly string ApiVersion = Google.Apis.Util.Utilities.GetLibraryVersion();

--- a/Src/GoogleApis.Core/Apis/Http/HttpExtenstions.cs
+++ b/Src/GoogleApis.Core/Apis/Http/HttpExtenstions.cs
@@ -23,7 +23,7 @@ namespace Google.Apis.Http
     /// Extension methods to <see cref="System.Net.Http.HttpRequestMessage"/> and 
     /// <see cref="System.Net.Http.HttpResponseMessage"/>.
     /// </summary>
-    static class HttpExtenstions
+    public static class HttpExtenstions
     {
         /// <summary>Returns <c>true</c> if the response contains one of the redirect status codes.</summary>
         internal static bool IsRedirectStatusCode(this HttpResponseMessage message)
@@ -40,8 +40,8 @@ namespace Google.Apis.Http
             }
         }
 
-        /// <summary>Sets an empty HTTP content.</summary>
-        internal static HttpContent SetEmptyContent(this HttpRequestMessage request)
+        /// <summary>A Google.Apis utility method for setting an empty HTTP content.</summary>
+        public static HttpContent SetEmptyContent(this HttpRequestMessage request)
         {
             request.Content = new ByteArrayContent(new byte[0]);
             request.Content.Headers.ContentLength = 0;

--- a/Src/GoogleApis.Core/Apis/Http/MaxUrlLengthInterceptor.cs
+++ b/Src/GoogleApis.Core/Apis/Http/MaxUrlLengthInterceptor.cs
@@ -35,7 +35,7 @@ namespace Google.Apis.Http
     /// </list>
     /// </summary>
     [VisibleForTestOnly]
-    internal class MaxUrlLengthInterceptor : IHttpExecuteInterceptor
+    public class MaxUrlLengthInterceptor : IHttpExecuteInterceptor
     {
         private readonly uint maxUrlLength;
 

--- a/Src/GoogleApis.Core/Apis/Requests/Parameters/ParameterValidator.cs
+++ b/Src/GoogleApis.Core/Apis/Requests/Parameters/ParameterValidator.cs
@@ -29,7 +29,7 @@ namespace Google.Apis.Requests.Parameters
     {
         /// <summary>Validates a parameter value against the methods regex.</summary>
         [VisibleForTestOnly]
-        internal static bool ValidateRegex(IParameter param, string paramValue)
+        public static bool ValidateRegex(IParameter param, string paramValue)
         {
             return string.IsNullOrEmpty(param.Pattern) || new Regex(param.Pattern).IsMatch(paramValue);
         }

--- a/Src/GoogleApis.Core/Apis/Testing/VisibleForTestOnly.cs
+++ b/Src/GoogleApis.Core/Apis/Testing/VisibleForTestOnly.cs
@@ -19,8 +19,8 @@ using System;
 namespace Google.Apis.Testing
 {
     /// <summary>
-    /// Marker Attribute to indicate a Method/Class/Property has been made more visible for
-    /// purpose of testing. Mark as internal and makr the testing assembly as friend using
+    /// Marker Attribute to indicate a Method/Class/Property has been made more visible for purpose of testing.
+    /// Mark the method as public, without making the testing assembly as friend using
     /// <code>[assembly: InternalsVisibleTo("Full.Name.Of.Testing.Assembly")]</code>
     /// </summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method | AttributeTargets.Property |

--- a/Src/GoogleApis.Core/Apis/Util/Utilities.cs
+++ b/Src/GoogleApis.Core/Apis/Util/Utilities.cs
@@ -21,19 +21,25 @@ using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
 
+using Google.Apis.Testing;
+
 namespace Google.Apis.Util
 {
     /// <summary>A utility class which contains helper methods and extension methods.</summary>
     public static class Utilities
     {
         /// <summary>Returns the version of the core library.</summary>
-        internal static string GetLibraryVersion()
+        [VisibleForTestOnly]
+        public static string GetLibraryVersion()
         {
             return Regex.Match(typeof(Utilities).Assembly.FullName, "Version=([\\d\\.]+)").Groups[1].ToString();
         }
 
-        /// <summary>Throws an <see cref="System.ArgumentNullException"/> if the object is null.</summary>
-        internal static T ThrowIfNull<T>(this T obj, string paramName)
+        /// <summary>
+        /// A Google.Apis utility method for throwing an <see cref="System.ArgumentNullException"/> if the object is
+        /// <c>null</c>.
+        /// </summary>
+        public static T ThrowIfNull<T>(this T obj, string paramName)
         {
             if (obj == null)
             {
@@ -44,10 +50,11 @@ namespace Google.Apis.Util
         }
 
         /// <summary>
-        /// Throws an <see cref="System.ArgumentNullException"/> if the string is <c>null</c> or empty.
+        /// A Google.Apis utility method for throwing an <see cref="System.ArgumentNullException"/> if the string is
+        /// <c>null</c> or empty.
         /// </summary>
         /// <returns>The original string.</returns>
-        internal static string ThrowIfNullOrEmpty(this string str, string paramName)
+        public static string ThrowIfNullOrEmpty(this string str, string paramName)
         {
             if (string.IsNullOrEmpty(str))
             {
@@ -62,8 +69,10 @@ namespace Google.Apis.Util
             return coll == null || coll.Count() == 0;
         }
 
-        /// <summary>Returns the first matching custom attribute (or <c>null</c>) of the specified member.</summary>
-        internal static T GetCustomAttribute<T>(this MemberInfo info) where T : Attribute
+        /// <summary>
+        /// A Google.Apis utility method for returning the first matching custom attribute (or <c>null</c>) of the specified member.
+        /// </summary>
+        public static T GetCustomAttribute<T>(this MemberInfo info) where T : Attribute
         {
             object[] results = info.GetCustomAttributes(typeof(T), false);
             return results.Length == 0 ? null : (T)results[0];
@@ -88,10 +97,19 @@ namespace Google.Apis.Util
         }
 
         /// <summary>
+        /// Returns the defined string value of an Enum. Use for test purposes or in other Google.Apis projects.
+        /// </summary>
+        public static string GetEnumStringValue(Enum value)
+        {
+            return value.GetStringValue();
+        }
+
+        /// <summary>
         /// Tries to convert the specified object to a string. Uses custom type converters if available.
         /// Returns null for a null object.
         /// </summary>
-        internal static string ConvertToString(object o)
+        [VisibleForTestOnly]
+        public static string ConvertToString(object o)
         {
             if (o == null)
             {

--- a/Src/GoogleApis.Core/ApplicationContext.cs
+++ b/Src/GoogleApis.Core/ApplicationContext.cs
@@ -24,8 +24,7 @@ namespace Google
     /// <summary>Defines the context in which this library runs. It allows setting up custom loggers.</summary>
     public static class ApplicationContext
     {
-        [VisibleForTestOnly]
-        internal static ILogger logger;
+        private static ILogger logger;
 
         /// <summary>Returns the logger used within this application context.</summary>
         /// <remarks>It creates a <see cref="NullLogger"/> if no logger was registered previously</remarks>

--- a/Src/GoogleApis.Core/Properties/AssemblyInfo.cs
+++ b/Src/GoogleApis.Core/Properties/AssemblyInfo.cs
@@ -29,11 +29,6 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-[assembly: InternalsVisibleTo("Google.Apis")]
-[assembly: InternalsVisibleTo("Google.Apis.Tests")]
-[assembly: InternalsVisibleTo("Google.Apis.Auth")]
-[assembly: InternalsVisibleTo("Google.Apis.Auth.PlatformServices")]
-
 // The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.

--- a/Src/GoogleApis.Tests/Apis/Services/BaseClientServiceTest.cs
+++ b/Src/GoogleApis.Tests/Apis/Services/BaseClientServiceTest.cs
@@ -73,7 +73,7 @@ namespace Google.Apis.Tests.Apis.Services
             var client = new MockClientService();
             if (features.HasValue)
             {
-                client.SetFeatures(new[] { features.Value.GetStringValue() });
+                client.SetFeatures(new[] { Utilities.GetEnumStringValue(features.Value) });
             }
 
             return client;

--- a/Src/GoogleApis.Tests/Apis/Utils/UtilitiesTest.cs
+++ b/Src/GoogleApis.Tests/Apis/Utils/UtilitiesTest.cs
@@ -49,10 +49,11 @@ namespace Google.Apis.Tests.Apis.Util
         [Test]
         public void StringValueTest()
         {
-            Assert.That(MockEnum.EntryWithStringValue.GetStringValue(), Is.EqualTo("Test"));
-            Assert.That(MockEnum.EntryWithSecondStringValue.GetStringValue(), Is.EqualTo("3.14159265358979323846"));
-            Assert.Throws<ArgumentException>(() => MockEnum.EntryWithoutStringValue.GetStringValue());
-            Assert.Throws<ArgumentNullException>(() => ((MockEnum)123456).GetStringValue());
+            Assert.That(Utilities.GetEnumStringValue(MockEnum.EntryWithStringValue), Is.EqualTo("Test"));
+            Assert.That(Utilities.GetEnumStringValue(MockEnum.EntryWithSecondStringValue), 
+                        Is.EqualTo("3.14159265358979323846"));
+            Assert.Throws<ArgumentException>(() => Utilities.GetEnumStringValue(MockEnum.EntryWithoutStringValue));
+            Assert.Throws<ArgumentNullException>(() => Utilities.GetEnumStringValue((MockEnum)123456));
         }
 
         /// <summary>Tests the "ConvertToString" method.</summary>

--- a/Src/GoogleApis.Tests/ApplicationContextTests.cs
+++ b/Src/GoogleApis.Tests/ApplicationContextTests.cs
@@ -92,9 +92,6 @@ namespace Google.Apis.Tests
 
             // Fail test:
             Assert.Throws<InvalidOperationException>(() => ApplicationContext.RegisterLogger(new MockLogger()));
-
-            // change back to default logger
-            ApplicationContext.logger = null;
         }
     }
 }

--- a/Src/GoogleApis/Apis/Requests/BatchRequest.cs
+++ b/Src/GoogleApis/Apis/Requests/BatchRequest.cs
@@ -290,7 +290,7 @@ namespace Google.Apis.Requests
         /// Creates the batch outer request content which includes all the individual requests to Google servers.
         /// </summary>
         [VisibleForTestOnly]
-        internal async static Task<HttpContent> CreateOuterRequestContent(IEnumerable<IClientServiceRequest> requests)
+        public async static Task<HttpContent> CreateOuterRequestContent(IEnumerable<IClientServiceRequest> requests)
         {
             var mixedContent = new MultipartContent("mixed");
             foreach (var request in requests)
@@ -313,7 +313,7 @@ namespace Google.Apis.Requests
 
         /// <summary>Creates the individual server request.</summary>
         [VisibleForTestOnly]
-        internal static async Task<HttpContent> CreateIndividualRequest(IClientServiceRequest request)
+        public static async Task<HttpContent> CreateIndividualRequest(IClientServiceRequest request)
         {
             HttpRequestMessage requestMessage = request.CreateRequest(false);
             string requestContent = await CreateRequestContentString(requestMessage).ConfigureAwait(false);
@@ -328,7 +328,7 @@ namespace Google.Apis.Requests
         /// request message.
         /// </summary>
         [VisibleForTestOnly]
-        internal static async Task<string> CreateRequestContentString(HttpRequestMessage requestMessage)
+        public static async Task<string> CreateRequestContentString(HttpRequestMessage requestMessage)
         {
             var sb = new StringBuilder();
             sb.AppendFormat("{0} {1}", requestMessage.Method, requestMessage.RequestUri.AbsoluteUri);

--- a/Src/GoogleApis/Apis/Requests/ClientServiceRequest.cs
+++ b/Src/GoogleApis/Apis/Requests/ClientServiceRequest.cs
@@ -257,7 +257,7 @@ namespace Google.Apis.Requests
 
         /// <summary>Returns the default ETagAction for a specific HTTP verb.</summary>
         [VisibleForTestOnly]
-        internal static ETagAction GetDefaultETagAction(string httpMethod)
+        public static ETagAction GetDefaultETagAction(string httpMethod)
         {
             switch (httpMethod)
             {

--- a/Src/GoogleApis/Apis/Services/BaseClientService.cs
+++ b/Src/GoogleApis/Apis/Services/BaseClientService.cs
@@ -53,7 +53,7 @@ namespace Google.Apis.Services
 
         /// <summary>The default maximum allowed length of a URL string for GET requests.</summary>
         [VisibleForTestOnly]
-        internal const uint DefaultMaxUrlLength = 2048;
+        public const uint DefaultMaxUrlLength = 2048;
 
         #region Initializer
 
@@ -139,7 +139,7 @@ namespace Google.Apis.Services
         /// <summary>Returns <c>true</c> if this service contains the specified feature.</summary>
         private bool HasFeature(Features feature)
         {
-            return Features.Contains(feature.GetStringValue());
+            return Features.Contains(Utilities.GetEnumStringValue(feature));
         }
 
         private ConfigurableHttpClient CreateHttpClient(Initializer initializer)

--- a/Src/GoogleApis/Apis/[Media]/Upload/ResumableUpload.cs
+++ b/Src/GoogleApis/Apis/[Media]/Upload/ResumableUpload.cs
@@ -174,8 +174,9 @@ namespace Google.Apis.Upload
         /// <summary>Gets or sets the body of this request.</summary>
         public TRequest Body { get; set; }
 
+        /// <summary>Change this value ONLY for testing purposes!</summary>
         [VisibleForTestOnly]
-        internal int chunkSize = DefaultChunkSize;
+        protected int chunkSize = DefaultChunkSize;
 
         /// <summary>
         /// Gets or sets the size of each chunk sent to the server.

--- a/Src/GoogleApis/Properties/AssemblyInfo.cs
+++ b/Src/GoogleApis/Properties/AssemblyInfo.cs
@@ -28,7 +28,6 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyCopyright("Copyright © Google Inc 2012")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
-[assembly: InternalsVisibleTo("Google.Apis.Tests")]
 
 // The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,


### PR DESCRIPTION
http://codereview.appspot.com/230740044/

This change is in order to eventually sign the dlls.
It seams that "friend assemblies" will make the process of signing our Google.Apis dlls just harder, and it is easy to remove the IntternalsVisibleTo attributes.