### PR TITLE
add JSON Service Account credential support

### DIFF
--- a/Src/GoogleApis.Auth.DotNet4/GoogleApis.Auth.DotNet4.csproj
+++ b/Src/GoogleApis.Auth.DotNet4/GoogleApis.Auth.DotNet4.csproj
@@ -46,6 +46,9 @@
     <AssemblyOriginatorKeyFile>C:\code\google.apis.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="BouncyCastle.Crypto">
+      <HintPath>..\..\packages\BouncyCastle.1.7.0\lib\Net40-Client\BouncyCastle.Crypto.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Threading.Tasks">
       <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
     </Reference>

--- a/Src/GoogleApis.Auth.DotNet4/packages.config
+++ b/Src/GoogleApis.Auth.DotNet4/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="BouncyCastle" version="1.7.0" targetFramework="net40" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net40" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net40" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net40" />

--- a/Tools/Google.Apis.Release/Resources/Google.Apis.Auth.VERSION.nuspec
+++ b/Tools/Google.Apis.Release/Resources/Google.Apis.Auth.VERSION.nuspec
@@ -25,7 +25,8 @@
         </description>
         <tags>Google</tags>
         <dependencies>
-            <dependency id="Google.Apis.Core" version="VERSION" />
+          <dependency id="BouncyCastle" version="1.7.0" />
+          <dependency id="Google.Apis.Core" version="VERSION" />
         </dependencies>
     </metadata>
     <files>


### PR DESCRIPTION
Adds support for JSON Service Account keys, generated from cloud console using the "Generate New JSON Key" option as described here https://developers.google.com/identity/protocols/OAuth2ServiceAccount.

This contains code of #552 (already LGTMd), rebased on top of upstream/master and with the commits squashed together to preserve clean git history.

FYI @vsubramani, who is the author of the code (as the commit author info suggests)