### PR TITLE
Fixing exception InvalidOperationException while authentication

### DIFF
--- a/Src/GoogleApis.Auth.WP/OAuth2/WebAuthenticationBrokerUserControl.xaml.cs
+++ b/Src/GoogleApis.Auth.WP/OAuth2/WebAuthenticationBrokerUserControl.xaml.cs
@@ -62,7 +62,7 @@ namespace Google.Apis.Auth.OAuth2
             if (e.Uri.Host == "localhost")
             {
                 var query = e.Uri.Query.Substring(1);
-                tcsAuthorizationCodeResponse.SetResult(new AuthorizationCodeResponseUrl(query));
+                tcsAuthorizationCodeResponse.TrySetResult(new AuthorizationCodeResponseUrl(query));
             }
         }
 
@@ -75,11 +75,11 @@ namespace Google.Apis.Auth.OAuth2
                 // If we encounter a null exception, cancel the task because the Windows Phone app crashed.
                 if (e.Exception != null)
                 {
-                    tcsAuthorizationCodeResponse.SetException(e.Exception);
+                    tcsAuthorizationCodeResponse.TrySetException(e.Exception);
                 }
                 else
                 {
-                    tcsAuthorizationCodeResponse.SetCanceled();
+                    tcsAuthorizationCodeResponse.TrySetCanceled();
                 }
             }
         }
@@ -109,7 +109,7 @@ namespace Google.Apis.Auth.OAuth2
         void RootPage_BackKeyPress(object sender, System.ComponentModel.CancelEventArgs e)
         {
             e.Cancel = true;
-            tcsAuthorizationCodeResponse.SetCanceled();
+            tcsAuthorizationCodeResponse.TrySetCanceled();
         }
 
         /// <summary>Removes <see cref="RootPage_BackKeyPress" as the root page callback./></summary>


### PR DESCRIPTION
It seems there is a rather serious problem with the GoogleWebAuthorizationBroker.AuthorizeAsync invocation. Somewhere deep inside the code flow there is WebAuthenticationBrokerUserControl class and the method OnBrowserNavigating. This method constantly throwing this exception

System.InvalidOperationException: An attempt was made to transition a task to a final state when it had already completed.
   at System.Threading.Tasks.TaskCompletionSource`1.SetResult(TResult result)
   at Google.Apis.Auth.OAuth2.WebAuthenticationBrokerUserControl.OnBrowserNavigating(Object sender, NavigatingEventArgs e)
   at Microsoft.Phone.Controls.WebBrowser.FireNavigatingEvent(Uri uri, Boolean& cancel) at Microsoft.Phone.Controls.WebBrowserInterop.ReversePInvokeThunk.OnNavigating(Int32 webBrowserControlId, String uri, Boolean& cancel)

   Changing Set methods to TrySet methods will resolve the issue. Why the method is called repeatedly and is this OK is a different question. Anyway changing the methods won't break anything, won't change the main logic but will fix the issue.
