### PR TITLE
Add params overload for GoogleCredential.CreateScoped

### DIFF
--- a/Src/GoogleApis.Auth.DotNet4.Tests/OAuth2/DefaultCredentialProviderTests.cs
+++ b/Src/GoogleApis.Auth.DotNet4.Tests/OAuth2/DefaultCredentialProviderTests.cs
@@ -184,17 +184,27 @@ MIICdgIBADANBgkqhkiG9w0BAQEFAASCAmAwggJcAgEAAoGBAJJM6HT4s6btOsfe
 
             Assert.IsInstanceOf(typeof(ServiceAccountCredential), credential.UnderlyingCredential);
             Assert.IsTrue(credential.IsCreateScopedRequired);
+        }
+
+        /// <summary>Test that adding scopes to GoogleCredential backed by a ServiceAccountCredential works correctly.</summary>
+        [Test]
+        public async Task GetDefaultCredential_ServiceAccountCredential_CreateScoped()
+        {
+            // Setup fake environment variables and credential file contents.
+            var credentialFilepath = "TempFilePath.json";
+            credentialProvider.SetEnvironmentVariable(CredentialEnvironmentVariable, credentialFilepath);
+            credentialProvider.SetFileContents(credentialFilepath, DummyServiceAccountCredentialFileContents);
+
+            var credential = await credentialProvider.GetDefaultCredentialAsync();
 
             var scopes = new[] { "https://www.googleapis.com/auth/cloud-platform" };
             var scopedCredential = credential.CreateScoped(scopes);
             Assert.AreNotSame(credential, scopedCredential);
-
-            Assert.IsInstanceOf(typeof(ServiceAccountCredential), scopedCredential.UnderlyingCredential);
             Assert.IsFalse(scopedCredential.IsCreateScopedRequired);
-            CollectionAssert.AreEqual(scopes, ((ServiceAccountCredential) scopedCredential.UnderlyingCredential).Scopes);
+            CollectionAssert.AreEqual(scopes, ((ServiceAccountCredential)scopedCredential.UnderlyingCredential).Scopes);
 
-            var scopedCredential2 = credential.CreateScoped("scope1", "scope2");
-            CollectionAssert.AreEqual(new[] { "scope1", "scope2" }, ((ServiceAccountCredential) scopedCredential2.UnderlyingCredential).Scopes);
+            scopedCredential = credential.CreateScoped("scope1", "scope2");  // Test the params overload
+            CollectionAssert.AreEqual(new[] { "scope1", "scope2" }, ((ServiceAccountCredential)scopedCredential.UnderlyingCredential).Scopes);
         }
 
         #endregion

--- a/Src/GoogleApis.Auth.DotNet4.Tests/OAuth2/DefaultCredentialProviderTests.cs
+++ b/Src/GoogleApis.Auth.DotNet4.Tests/OAuth2/DefaultCredentialProviderTests.cs
@@ -192,6 +192,9 @@ MIICdgIBADANBgkqhkiG9w0BAQEFAASCAmAwggJcAgEAAoGBAJJM6HT4s6btOsfe
             Assert.IsInstanceOf(typeof(ServiceAccountCredential), scopedCredential.UnderlyingCredential);
             Assert.IsFalse(scopedCredential.IsCreateScopedRequired);
             CollectionAssert.AreEqual(scopes, ((ServiceAccountCredential) scopedCredential.UnderlyingCredential).Scopes);
+
+            var scopedCredential2 = credential.CreateScoped("scope1", "scope2");
+            CollectionAssert.AreEqual(new[] { "scope1", "scope2" }, ((ServiceAccountCredential) scopedCredential2.UnderlyingCredential).Scopes);
         }
 
         #endregion

--- a/Src/GoogleApis.Auth.DotNet4/OAuth2/GoogleCredential.cs
+++ b/Src/GoogleApis.Auth.DotNet4/OAuth2/GoogleCredential.cs
@@ -122,6 +122,12 @@ namespace Google.Apis.Auth.OAuth2
             return this;
         }
 
+        /// <summary>If the credential supports scopes, creates a copy with the specified scopes, otherwise it returns the same instance.</summary>
+        public GoogleCredential CreateScoped(params string[] scopes)
+        {
+            return CreateScoped((IEnumerable<string>) scopes);
+        }
+
         #region IConfigurableHttpClientInitializer
 
         void IConfigurableHttpClientInitializer.Initialize(ConfigurableHttpClient httpClient)


### PR DESCRIPTION
Fixes #585.