### PR TITLE
BaseClientService isn't thread-safe

### DIFF
--- a/Src/GoogleApis.Auth/OAuth2/ServiceCredential.cs
+++ b/Src/GoogleApis.Auth/OAuth2/ServiceCredential.cs
@@ -155,8 +155,8 @@ namespace Google.Apis.Auth.OAuth2
 
         public void Initialize(ConfigurableHttpClient httpClient)
         {
-            httpClient.MessageHandler.ExecuteInterceptors.Add(this);
-            httpClient.MessageHandler.UnsuccessfulResponseHandlers.Add(this);
+            httpClient.MessageHandler.AddExecuteInterceptor(this);
+            httpClient.MessageHandler.AddUnsuccessfulResponseHandler(this);
         }
 
         #endregion

--- a/Src/GoogleApis.Auth/OAuth2/UserCredential.cs
+++ b/Src/GoogleApis.Auth/OAuth2/UserCredential.cs
@@ -118,8 +118,8 @@ namespace Google.Apis.Auth.OAuth2
 
         public void Initialize(ConfigurableHttpClient httpClient)
         {
-            httpClient.MessageHandler.ExecuteInterceptors.Add(this);
-            httpClient.MessageHandler.UnsuccessfulResponseHandlers.Add(this);
+            httpClient.MessageHandler.AddExecuteInterceptor(this);
+            httpClient.MessageHandler.AddUnsuccessfulResponseHandler(this);
         }
 
         #endregion

--- a/Src/GoogleApis.Core/Apis/Http/ConfigurableMessageHandler.cs
+++ b/Src/GoogleApis.Core/Apis/Http/ConfigurableMessageHandler.cs
@@ -75,10 +75,10 @@ namespace Google.Apis.Http
             new List<IHttpExecuteInterceptor>();
 
         /// <summary>
-        /// Gets a copied list of <see cref="IHttpUnsuccessfulResponseHandler"/>.
+        /// Gets a snapshot of <see cref="IHttpUnsuccessfulResponseHandler"/>s associated with this instance's handlers.
         /// <remarks>
         /// Since version 1.10, the return value had been changed from <c>IList</c> to <c>IEnumerable</c> in order to
-        /// keep this class thread-safe. The returned list is also a copied version of the handlers. More info is
+        /// keep this class thread-safe. The returned enumerable is a snapshot version of the handlers. More info is
         /// available on <a href="https://github.com/google/google-api-dotnet-client/issues/592">Issue 592</a>.
         /// </remarks>
         /// </summary>
@@ -112,10 +112,10 @@ namespace Google.Apis.Http
         }
 
         /// <summary>
-        /// Gets a list of <see cref="IHttpExceptionHandler"/>.
+        /// Gets a snapshot of <see cref="IHttpExceptionHandler"/>s associated with this instance's handlers.
         /// <remarks>
         /// Since version 1.10, the return value had been changed from <c>IList</c> to <c>IEnumerable</c> in order to
-        /// keep this class thread-safe. The returned list is also a copied version of the handlers. More info is
+        /// keep this class thread-safe. The returned enumerable is a snapshot version of the handlers. More info is
         /// available on <a href="https://github.com/google/google-api-dotnet-client/issues/592">Issue 592</a>.
         /// </remarks>
         /// </summary>
@@ -149,11 +149,11 @@ namespace Google.Apis.Http
         }
 
         /// <summary>
-        /// Gets a list of <see cref="IHttpExecuteInterceptor"/>.
+        /// Gets a snapshot of <see cref="IHttpExecuteInterceptor"/>s associated with this instance's interceptors.
         /// <remarks>
         /// Since version 1.10, the return value had been changed from <c>IList</c> to <c>IEnumerable</c> in order to
-        /// keep this class thread-safe. The returned list is also a copied version of the interceptors. More info is
-        /// available on <a href="https://github.com/google/google-api-dotnet-client/issues/592">Issue 592</a>.
+        /// keep this class thread-safe. The returned enumerable is a snapshot version of the interceptors. More info
+        /// is available on <a href="https://github.com/google/google-api-dotnet-client/issues/592">Issue 592</a>.
         /// </remarks>
         /// </summary>
         public IEnumerable<IHttpExecuteInterceptor> ExecuteInterceptors

--- a/Src/GoogleApis.Core/Apis/Http/ConfigurableMessageHandler.cs
+++ b/Src/GoogleApis.Core/Apis/Http/ConfigurableMessageHandler.cs
@@ -75,7 +75,7 @@ namespace Google.Apis.Http
             new List<IHttpExecuteInterceptor>();
 
         /// <summary>
-        /// Gets a snapshot of <see cref="IHttpUnsuccessfulResponseHandler"/>s associated with this instance's handlers.
+        /// Gets a <b>snapshot</b> of <see cref="IHttpUnsuccessfulResponseHandler"/>s associated with this instance.
         /// <remarks>
         /// Since version 1.10, the return value had been changed from <c>IList</c> to <c>IEnumerable</c> in order to
         /// keep this class thread-safe. The returned enumerable is a snapshot version of the handlers. More info is
@@ -112,7 +112,7 @@ namespace Google.Apis.Http
         }
 
         /// <summary>
-        /// Gets a snapshot of <see cref="IHttpExceptionHandler"/>s associated with this instance's handlers.
+        /// Gets a <b>snapshot</b> of <see cref="IHttpExceptionHandler"/>s associated with this instance.
         /// <remarks>
         /// Since version 1.10, the return value had been changed from <c>IList</c> to <c>IEnumerable</c> in order to
         /// keep this class thread-safe. The returned enumerable is a snapshot version of the handlers. More info is
@@ -149,7 +149,7 @@ namespace Google.Apis.Http
         }
 
         /// <summary>
-        /// Gets a snapshot of <see cref="IHttpExecuteInterceptor"/>s associated with this instance's interceptors.
+        /// Gets a <b>snapshot</b> of <see cref="IHttpExecuteInterceptor"/>s associated with this instance.
         /// <remarks>
         /// Since version 1.10, the return value had been changed from <c>IList</c> to <c>IEnumerable</c> in order to
         /// keep this class thread-safe. The returned enumerable is a snapshot version of the interceptors. More info

--- a/Src/GoogleApis.Core/Apis/Http/ConfigurableMessageHandler.cs
+++ b/Src/GoogleApis.Core/Apis/Http/ConfigurableMessageHandler.cs
@@ -52,6 +52,16 @@ namespace Google.Apis.Http
 
         #region IHttpUnsuccessfulResponseHandler, IHttpExceptionHandler and IHttpExecuteInterceptor lists
 
+        #region Lock objects
+
+        // The following lock objects are used to lock the list of handlers and interceptors in order to be able to
+        // iterate over them from several threads and to keep this class thread-safe.
+        private readonly object unsuccessfulResponseHandlersLock = new object();
+        private readonly object exceptionHandlersLock = new object();
+        private readonly object executeInterceptorsLock = new object();
+
+        #endregion
+
         /// <summary>A list of <see cref="IHttpUnsuccessfulResponseHandler"/>.</summary>
         private readonly IList<IHttpUnsuccessfulResponseHandler> unsuccessfulResponseHandlers =
             new List<IHttpUnsuccessfulResponseHandler>();
@@ -64,22 +74,115 @@ namespace Google.Apis.Http
         private readonly IList<IHttpExecuteInterceptor> executeInterceptors =
             new List<IHttpExecuteInterceptor>();
 
-        /// <summary>Gets a list of <see cref="IHttpUnsuccessfulResponseHandler"/>.</summary>
-        public IList<IHttpUnsuccessfulResponseHandler> UnsuccessfulResponseHandlers
+        /// <summary>
+        /// Gets a copied list of <see cref="IHttpUnsuccessfulResponseHandler"/>.
+        /// <remarks>
+        /// Since version 1.10, the return value had been changed from <c>IList</c> to <c>IEnumerable</c> in order to
+        /// keep this class thread-safe. The returned list is also a copied version of the handlers. More info is
+        /// available on <a href="https://github.com/google/google-api-dotnet-client/issues/592">Issue 592</a>.
+        /// </remarks>
+        /// </summary>
+        public IEnumerable<IHttpUnsuccessfulResponseHandler> UnsuccessfulResponseHandlers
         {
-            get { return unsuccessfulResponseHandlers; }
+            get
+            {
+                lock (unsuccessfulResponseHandlersLock)
+                {
+                    return unsuccessfulResponseHandlers.ToList();
+                }
+            }
         }
 
-        /// <summary>Gets a list of <see cref="IHttpExceptionHandler"/>.</summary>
-        public IList<IHttpExceptionHandler> ExceptionHandlers
+        /// <summary>Adds the specified handler to the list of unsuccessful response handlers.</summary>
+        public void AddUnsuccessfulResponseHandler(IHttpUnsuccessfulResponseHandler handler)
         {
-            get { return exceptionHandlers; }
+            lock (unsuccessfulResponseHandlersLock)
+            {
+                unsuccessfulResponseHandlers.Add(handler);
+            }
         }
 
-        /// <summary>Gets a list of <see cref="IHttpExecuteInterceptor"/>.</summary>
-        public IList<IHttpExecuteInterceptor> ExecuteInterceptors
+        /// <summary>Removes the specified handler from the list of unsuccessful response handlers.</summary>
+        public void RemoveUnsuccessfulResponseHandler(IHttpUnsuccessfulResponseHandler handler)
         {
-            get { return executeInterceptors; }
+            lock (unsuccessfulResponseHandlersLock)
+            {
+                unsuccessfulResponseHandlers.Remove(handler);
+            }
+        }
+
+        /// <summary>
+        /// Gets a list of <see cref="IHttpExceptionHandler"/>.
+        /// <remarks>
+        /// Since version 1.10, the return value had been changed from <c>IList</c> to <c>IEnumerable</c> in order to
+        /// keep this class thread-safe. The returned list is also a copied version of the handlers. More info is
+        /// available on <a href="https://github.com/google/google-api-dotnet-client/issues/592">Issue 592</a>.
+        /// </remarks>
+        /// </summary>
+        public IEnumerable<IHttpExceptionHandler> ExceptionHandlers
+        {
+            get
+            {
+                lock (exceptionHandlersLock)
+                {
+                    return exceptionHandlers.ToList();
+                }
+            }
+        }
+
+        /// <summary>Adds the specified handler to the list of exception handlers.</summary>
+        public void AddExceptionHandler(IHttpExceptionHandler handler)
+        {
+            lock (exceptionHandlersLock)
+            {
+                exceptionHandlers.Add(handler);
+            }
+        }
+
+        /// <summary>Removes the specified handler from the list of exception handlers.</summary>
+        public void RemoveExceptionHandler(IHttpExceptionHandler handler)
+        {
+            lock (exceptionHandlersLock)
+            {
+                exceptionHandlers.Remove(handler);
+            }
+        }
+
+        /// <summary>
+        /// Gets a list of <see cref="IHttpExecuteInterceptor"/>.
+        /// <remarks>
+        /// Since version 1.10, the return value had been changed from <c>IList</c> to <c>IEnumerable</c> in order to
+        /// keep this class thread-safe. The returned list is also a copied version of the interceptors. More info is
+        /// available on <a href="https://github.com/google/google-api-dotnet-client/issues/592">Issue 592</a>.
+        /// </remarks>
+        /// </summary>
+        public IEnumerable<IHttpExecuteInterceptor> ExecuteInterceptors
+        {
+            get
+            {
+                lock (executeInterceptorsLock)
+                {
+                    return executeInterceptors.ToList();
+                }
+            }
+        }
+
+        /// <summary>Adds the specified interceptor to the list of execute interceptors.</summary>
+        public void AddExecuteInterceptor(IHttpExecuteInterceptor interceptor)
+        {
+            lock (executeInterceptorsLock)
+            {
+                executeInterceptors.Add(interceptor);
+            }
+        }
+
+        /// <summary>Removes the specified interceptor from the list of execute interceptors.</summary>
+        public void RemoveExecuteInterceptor(IHttpExecuteInterceptor interceptor)
+        {
+            lock (executeInterceptorsLock)
+            {
+                executeInterceptors.Remove(interceptor);
+            }
         }
 
         #endregion
@@ -186,8 +289,15 @@ namespace Google.Apis.Http
                 }
                 lastException = null;
 
+                // We keep a local list of the interceptors, since we can't call await inside lock.
+                IEnumerable<IHttpExecuteInterceptor> interceptors;
+                lock (executeInterceptorsLock)
+                {
+                    interceptors = executeInterceptors.ToList();
+                }
+
                 // Intercept the request.
-                foreach (var interceptor in executeInterceptors)
+                foreach (var interceptor in interceptors)
                 {
                     await interceptor.InterceptAsync(request, cancellationToken).ConfigureAwait(false);
                 }
@@ -213,8 +323,15 @@ namespace Google.Apis.Http
                 {
                     var exceptionHandled = false;
 
+                    // We keep a local list of the handlers, since we can't call await inside lock.
+                    IEnumerable<IHttpExceptionHandler> handlers;
+                    lock (exceptionHandlersLock)
+                    {
+                        handlers = exceptionHandlers.ToList();
+                    }
+
                     // Try to handle the exception with each handler.
-                    foreach (var handler in exceptionHandlers)
+                    foreach (var handler in handlers)
                     {
                         exceptionHandled |= await handler.HandleExceptionAsync(new HandleExceptionArgs
                             {
@@ -249,8 +366,14 @@ namespace Google.Apis.Http
                     {
                         bool errorHandled = false;
 
+                        // We keep a local list of the handlers, since we can't call await inside lock.
+                        IEnumerable<IHttpUnsuccessfulResponseHandler> handlers;
+                        lock (unsuccessfulResponseHandlersLock)
+                        {
+                            handlers = unsuccessfulResponseHandlers.ToList();
+                        }
                         // Try to handle the abnormal HTTP response with each handler.
-                        foreach (var handler in unsuccessfulResponseHandlers)
+                        foreach (var handler in handlers)
                         {
                             errorHandled |= await handler.HandleResponseAsync(new HandleUnsuccessfulResponseArgs
                                 {

--- a/Src/GoogleApis.Core/Apis/Http/ExponentialBackOffInitializer.cs
+++ b/Src/GoogleApis.Core/Apis/Http/ExponentialBackOffInitializer.cs
@@ -64,13 +64,13 @@ namespace Google.Apis.Http
             // Add exception handler and \ or unsuccessful response handler.
             if ((Policy & ExponentialBackOffPolicy.Exception) == ExponentialBackOffPolicy.Exception)
             {
-                httpClient.MessageHandler.ExceptionHandlers.Add(backOff);
+                httpClient.MessageHandler.AddExceptionHandler(backOff);
             }
 
             if ((Policy & ExponentialBackOffPolicy.UnsuccessfulResponse503) ==
                 ExponentialBackOffPolicy.UnsuccessfulResponse503)
             {
-                httpClient.MessageHandler.UnsuccessfulResponseHandlers.Add(backOff);
+                httpClient.MessageHandler.AddUnsuccessfulResponseHandler(backOff);
             }
         }
     }

--- a/Src/GoogleApis.Tests/Apis/Http/ConfigurableMessageHandlerTest.cs
+++ b/Src/GoogleApis.Tests/Apis/Http/ConfigurableMessageHandlerTest.cs
@@ -238,7 +238,7 @@ namespace Google.Apis.Tests.Apis.Http
 
             var configurableHanlder = new ConfigurableMessageHandler(handler);
             var interceptor = new InterceptorMessageHandler.Interceptor();
-            configurableHanlder.ExecuteInterceptors.Add(interceptor);
+            configurableHanlder.AddExecuteInterceptor(interceptor);
 
             using (var client = new HttpClient(configurableHanlder))
             {
@@ -265,8 +265,8 @@ namespace Google.Apis.Tests.Apis.Http
 
             var configurableHanlder = new ConfigurableMessageHandler(handler);
             var interceptor = new InterceptorMessageHandler.Interceptor();
-            configurableHanlder.ExecuteInterceptors.Add(interceptor);
-            configurableHanlder.UnsuccessfulResponseHandlers.Add(new TrueUnsuccessfulResponseHandler());
+            configurableHanlder.AddExecuteInterceptor(interceptor);
+            configurableHanlder.AddUnsuccessfulResponseHandler(new TrueUnsuccessfulResponseHandler());
 
             using (var client = new HttpClient(configurableHanlder))
             {
@@ -333,7 +333,7 @@ namespace Google.Apis.Tests.Apis.Http
 
             var configurableHanlder = new ConfigurableMessageHandler(handler);
             var unsuccessfulHandler = new UnsuccessfulResponseMessageHandler.ServiceUnavailableResponseHandler();
-            configurableHanlder.UnsuccessfulResponseHandlers.Add(unsuccessfulHandler);
+            configurableHanlder.AddUnsuccessfulResponseHandler(unsuccessfulHandler);
 
             using (var client = new HttpClient(configurableHanlder))
             {
@@ -471,7 +471,7 @@ namespace Google.Apis.Tests.Apis.Http
 
             var configurableHanlder = new ConfigurableMessageHandler(handler);
             var exceptionHandler = new ExceptionMessageHandler.ExceptionHandler { Handle = handle };
-            configurableHanlder.ExceptionHandlers.Add(exceptionHandler);
+            configurableHanlder.AddExceptionHandler(exceptionHandler);
 
             using (var client = new HttpClient(configurableHanlder))
             {
@@ -652,7 +652,7 @@ namespace Google.Apis.Tests.Apis.Http
 
             var configurableHanlder = new ConfigurableMessageHandler(handler);
             var boHandler = new MockBackOffHandler(initializer);
-            configurableHanlder.ExceptionHandlers.Add(boHandler);
+            configurableHanlder.AddExceptionHandler(boHandler);
 
             int boHandleCount = 0;
             // if an exception should be thrown and the handler can handle it then calculate the handle count by the 
@@ -772,7 +772,7 @@ namespace Google.Apis.Tests.Apis.Http
                     NumTries = numTries
                 };
             var boHandler = new MockBackOffHandler(initializer);
-            configurableHanlder.UnsuccessfulResponseHandlers.Add(boHandler);
+            configurableHanlder.AddUnsuccessfulResponseHandler(boHandler);
 
             int boHandleCount = 0;
             if (initializer.HandleUnsuccessfulResponseFunc != null &&
@@ -860,7 +860,7 @@ namespace Google.Apis.Tests.Apis.Http
                 {
                     NumTries = 10
                 };
-            configurableHanlder.UnsuccessfulResponseHandlers.Add(new TrueUnsuccessfulResponseHandler());
+            configurableHanlder.AddUnsuccessfulResponseHandler(new TrueUnsuccessfulResponseHandler());
             using (var client = new HttpClient(configurableHanlder))
             {
                 var request = new HttpRequestMessage(HttpMethod.Put, "https://test-unsuccessful-handler");
@@ -989,7 +989,7 @@ namespace Google.Apis.Tests.Apis.Http
             if (handle)
             {
                 var unsuccessfulHandler = new UnsuccessfulResponseMessageHandler.ServiceUnavailableResponseHandler();
-                configurableHanlder.UnsuccessfulResponseHandlers.Add(unsuccessfulHandler);
+                configurableHanlder.AddUnsuccessfulResponseHandler(unsuccessfulHandler);
             }
 
             using (var client = new HttpClient(configurableHanlder))

--- a/Src/GoogleApis.Tests/Apis/Http/MaxUrlLengthInterceptorTest.cs
+++ b/Src/GoogleApis.Tests/Apis/Http/MaxUrlLengthInterceptorTest.cs
@@ -76,7 +76,7 @@ namespace Google.Apis.Tests.Apis.Http
             var request = new HttpRequestMessage(method, requestUri);
             var mockHandler = new MockMessageHandler();
             var handler = new ConfigurableMessageHandler(mockHandler);
-            handler.ExecuteInterceptors.Add(new MaxUrlLengthInterceptor(DefaultMaxUrlLength));
+            handler.AddExecuteInterceptor(new MaxUrlLengthInterceptor(DefaultMaxUrlLength));
             using (var httpClient = new HttpClient(handler))
             {
                 httpClient.SendAsync(request);
@@ -105,7 +105,7 @@ namespace Google.Apis.Tests.Apis.Http
             var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
             var mockHandler = new MockMessageHandler();
             var handler = new ConfigurableMessageHandler(mockHandler);
-            handler.ExecuteInterceptors.Add(new MaxUrlLengthInterceptor(maxUrlLength));
+            handler.AddExecuteInterceptor(new MaxUrlLengthInterceptor(maxUrlLength));
             using (var httpClient = new HttpClient(handler))
             {
                 httpClient.SendAsync(request);
@@ -129,7 +129,7 @@ namespace Google.Apis.Tests.Apis.Http
             var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
             var mockHandler = new MockMessageHandler();
             var handler = new ConfigurableMessageHandler(mockHandler);
-            handler.ExecuteInterceptors.Add(new MaxUrlLengthInterceptor(maxUrlLength));
+            handler.AddExecuteInterceptor(new MaxUrlLengthInterceptor(maxUrlLength));
             using (var httpClient = new HttpClient(handler))
             {
                 httpClient.SendAsync(request);

--- a/Src/GoogleApis.Tests/Apis/Requests/ClientServiceRequestTest.cs
+++ b/Src/GoogleApis.Tests/Apis/Requests/ClientServiceRequestTest.cs
@@ -348,7 +348,7 @@ namespace Google.Apis.Tests.Apis.Requests
             {
                 public void Initialize(ConfigurableHttpClient httpClient)
                 {
-                    httpClient.MessageHandler.UnsuccessfulResponseHandlers.Add(
+                    httpClient.MessageHandler.AddUnsuccessfulResponseHandler(
                         new ServiceUnavailableUnsuccessfulResponseHandler());
                 }
             }

--- a/Src/GoogleApis.Tests/Apis/Services/BaseClientServiceTest.cs
+++ b/Src/GoogleApis.Tests/Apis/Services/BaseClientServiceTest.cs
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -262,13 +263,15 @@ namespace Google.Apis.Tests.Apis.Services
             Assert.True(service.GZipEnabled);
 
             // Back-off handler for unsuccessful response (503) is added by default.
-            Assert.That(service.HttpClient.MessageHandler.UnsuccessfulResponseHandlers.Count, Is.EqualTo(1));
-            Assert.That(service.HttpClient.MessageHandler.UnsuccessfulResponseHandlers[0],
+            Assert.That(new List<IHttpUnsuccessfulResponseHandler>
+                (service.HttpClient.MessageHandler.UnsuccessfulResponseHandlers).Count, Is.EqualTo(1));
+            Assert.That(service.HttpClient.MessageHandler.UnsuccessfulResponseHandlers.FirstOrDefault(),
                 Is.InstanceOf<BackOffHandler>());
 
             // An execute interceptors is expected (for handling GET requests with URLs that are too long)
-            Assert.That(service.HttpClient.MessageHandler.ExecuteInterceptors.Count, Is.EqualTo(1));
-            Assert.That(service.HttpClient.MessageHandler.ExecuteInterceptors[0],
+            Assert.That(new List<IHttpExecuteInterceptor>
+                (service.HttpClient.MessageHandler.ExecuteInterceptors).Count, Is.EqualTo(1));
+            Assert.That(service.HttpClient.MessageHandler.ExecuteInterceptors.FirstOrDefault(),
                 Is.InstanceOf<MaxUrlLengthInterceptor>());
         }
 

--- a/Src/GoogleApis/Apis/Services/BaseClientService.cs
+++ b/Src/GoogleApis/Apis/Services/BaseClientService.cs
@@ -168,8 +168,7 @@ namespace Google.Apis.Services
             var httpClient = factory.CreateHttpClient(args);
             if (initializer.MaxUrlLength > 0)
             {
-                httpClient.MessageHandler.ExecuteInterceptors.Add(
-                    new MaxUrlLengthInterceptor(initializer.MaxUrlLength));
+                httpClient.MessageHandler.AddExecuteInterceptor(new MaxUrlLengthInterceptor(initializer.MaxUrlLength));
             }
             return httpClient;
         }

--- a/Src/GoogleApis/Apis/[Media]/Upload/ResumableUpload.cs
+++ b/Src/GoogleApis/Apis/[Media]/Upload/ResumableUpload.cs
@@ -224,8 +224,8 @@ namespace Google.Apis.Upload
             public ServerErrorCallback(ResumableUpload<TRequest> resumable)
             {
                 this.Owner = resumable;
-                Owner.Service.HttpClient.MessageHandler.UnsuccessfulResponseHandlers.Add(this);
-                Owner.Service.HttpClient.MessageHandler.ExceptionHandlers.Add(this);
+                Owner.Service.HttpClient.MessageHandler.AddUnsuccessfulResponseHandler(this);
+                Owner.Service.HttpClient.MessageHandler.AddExceptionHandler(this);
             }
 
             public Task<bool> HandleResponseAsync(HandleUnsuccessfulResponseArgs args)
@@ -271,8 +271,8 @@ namespace Google.Apis.Upload
 
             public void Dispose()
             {
-                Owner.Service.HttpClient.MessageHandler.UnsuccessfulResponseHandlers.Remove(this);
-                Owner.Service.HttpClient.MessageHandler.ExceptionHandlers.Remove(this);
+                Owner.Service.HttpClient.MessageHandler.RemoveUnsuccessfulResponseHandler(this);
+                Owner.Service.HttpClient.MessageHandler.RemoveExceptionHandler(this);
             }
         }
 


### PR DESCRIPTION
Solve #592. Change the API of ConfigurableMessageHandler to expose an
enumerable of handlers and interceptors and NOT a list.