### PR TITLE
Incremental auth support

### DIFF
--- a/Src/GoogleApis.Auth.DotNet4/OAuth2/GoogleWebAuthorizationBroker.cs
+++ b/Src/GoogleApis.Auth.DotNet4/OAuth2/GoogleWebAuthorizationBroker.cs
@@ -50,14 +50,14 @@ namespace Google.Apis.Auth.OAuth2
         /// <returns>User credential.</returns>
         public static async Task<UserCredential> AuthorizeAsync(ClientSecrets clientSecrets,
             IEnumerable<string> scopes, string user, CancellationToken taskCancellationToken,
-            IDataStore dataStore = null, bool? includeGrantedScopes = null)
+            IDataStore dataStore = null)
         {
             var initializer = new GoogleAuthorizationCodeFlow.Initializer
             {
                 ClientSecrets = clientSecrets,
             };
-            return await AuthorizeAsyncCore(initializer, scopes, user, taskCancellationToken, dataStore,
-                includeGrantedScopes).ConfigureAwait(false);
+            return await AuthorizeAsync(initializer, scopes, user, taskCancellationToken, dataStore)
+                .ConfigureAwait(false);
         }
 
         /// <summary>Asynchronously authorizes the specified user.</summary>
@@ -77,14 +77,14 @@ namespace Google.Apis.Auth.OAuth2
         /// <returns>User credential.</returns>
         public static async Task<UserCredential> AuthorizeAsync(Stream clientSecretsStream,
             IEnumerable<string> scopes, string user, CancellationToken taskCancellationToken,
-            IDataStore dataStore = null, bool? includeGrantedScopes = null)
+            IDataStore dataStore = null)
         {
             var initializer = new GoogleAuthorizationCodeFlow.Initializer
             {
                 ClientSecretsStream = clientSecretsStream,
             };
-            return await AuthorizeAsyncCore(initializer, scopes, user, taskCancellationToken,
-                dataStore, includeGrantedScopes).ConfigureAwait(false);
+            return await AuthorizeAsync(initializer, scopes, user, taskCancellationToken, dataStore)
+                .ConfigureAwait(false);
         }
 
         /// <summary>
@@ -113,22 +113,17 @@ namespace Google.Apis.Auth.OAuth2
         /// <param name="taskCancellationToken">Cancellation token to cancel an operation.</param>
         /// <param name="dataStore">The data store, if not specified a file data store will be used.</param>
         /// <returns>User credential.</returns>
-        public static async Task<UserCredential> AuthorizeAsyncCore(
+        public static async Task<UserCredential> AuthorizeAsync(
             GoogleAuthorizationCodeFlow.Initializer initializer, IEnumerable<string> scopes, string user,
-            CancellationToken taskCancellationToken, IDataStore dataStore = null,
-            bool? includeGrantedScopes = null)
+            CancellationToken taskCancellationToken, IDataStore dataStore = null)
         {
             initializer.Scopes = scopes;
             initializer.DataStore = dataStore ?? new FileDataStore(Folder);
-            if (includeGrantedScopes.HasValue)
-            {
-                initializer.IncludeGrantedScopes = includeGrantedScopes.Value;
-            }
             var flow = new GoogleAuthorizationCodeFlow(initializer);
 
             // Create an authorization code installed app instance and authorize the user.
-            return await new AuthorizationCodeInstalledApp(flow, new LocalServerCodeReceiver())
-                .AuthorizeAsync(user, taskCancellationToken).ConfigureAwait(false);
+            return await new AuthorizationCodeInstalledApp(flow, new LocalServerCodeReceiver()).AuthorizeAsync
+                (user, taskCancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/Src/GoogleApis.Auth.DotNet4/OAuth2/GoogleWebAuthorizationBroker.cs
+++ b/Src/GoogleApis.Auth.DotNet4/OAuth2/GoogleWebAuthorizationBroker.cs
@@ -113,14 +113,17 @@ namespace Google.Apis.Auth.OAuth2
         /// <param name="taskCancellationToken">Cancellation token to cancel an operation.</param>
         /// <param name="dataStore">The data store, if not specified a file data store will be used.</param>
         /// <returns>User credential.</returns>
-        private static async Task<UserCredential> AuthorizeAsyncCore(
+        public static async Task<UserCredential> AuthorizeAsyncCore(
             GoogleAuthorizationCodeFlow.Initializer initializer, IEnumerable<string> scopes, string user,
             CancellationToken taskCancellationToken, IDataStore dataStore = null,
             bool? includeGrantedScopes = null)
         {
             initializer.Scopes = scopes;
             initializer.DataStore = dataStore ?? new FileDataStore(Folder);
-            initializer.IncludeGrantedScopes = includeGrantedScopes;
+            if (includeGrantedScopes.HasValue)
+            {
+                initializer.IncludeGrantedScopes = includeGrantedScopes.Value;
+            }
             var flow = new GoogleAuthorizationCodeFlow(initializer);
 
             // Create an authorization code installed app instance and authorize the user.

--- a/Src/GoogleApis.Auth.DotNet4/OAuth2/GoogleWebAuthorizationBroker.cs
+++ b/Src/GoogleApis.Auth.DotNet4/OAuth2/GoogleWebAuthorizationBroker.cs
@@ -50,14 +50,14 @@ namespace Google.Apis.Auth.OAuth2
         /// <returns>User credential.</returns>
         public static async Task<UserCredential> AuthorizeAsync(ClientSecrets clientSecrets,
             IEnumerable<string> scopes, string user, CancellationToken taskCancellationToken,
-            IDataStore dataStore = null)
+            IDataStore dataStore = null, bool? includeGrantedScopes = null)
         {
             var initializer = new GoogleAuthorizationCodeFlow.Initializer
             {
                 ClientSecrets = clientSecrets,
             };
-            return await AuthorizeAsyncCore(initializer, scopes, user, taskCancellationToken, dataStore)
-                .ConfigureAwait(false);
+            return await AuthorizeAsyncCore(initializer, scopes, user, taskCancellationToken, dataStore,
+                includeGrantedScopes).ConfigureAwait(false);
         }
 
         /// <summary>Asynchronously authorizes the specified user.</summary>
@@ -77,14 +77,14 @@ namespace Google.Apis.Auth.OAuth2
         /// <returns>User credential.</returns>
         public static async Task<UserCredential> AuthorizeAsync(Stream clientSecretsStream,
             IEnumerable<string> scopes, string user, CancellationToken taskCancellationToken,
-            IDataStore dataStore = null)
+            IDataStore dataStore = null, bool? includeGrantedScopes = null)
         {
             var initializer = new GoogleAuthorizationCodeFlow.Initializer
             {
                 ClientSecretsStream = clientSecretsStream,
             };
-            return await AuthorizeAsyncCore(initializer, scopes, user, taskCancellationToken, dataStore)
-                .ConfigureAwait(false);
+            return await AuthorizeAsyncCore(initializer, scopes, user, taskCancellationToken,
+                dataStore, includeGrantedScopes).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -115,15 +115,17 @@ namespace Google.Apis.Auth.OAuth2
         /// <returns>User credential.</returns>
         private static async Task<UserCredential> AuthorizeAsyncCore(
             GoogleAuthorizationCodeFlow.Initializer initializer, IEnumerable<string> scopes, string user,
-            CancellationToken taskCancellationToken, IDataStore dataStore = null)
+            CancellationToken taskCancellationToken, IDataStore dataStore = null,
+            bool? includeGrantedScopes = null)
         {
             initializer.Scopes = scopes;
             initializer.DataStore = dataStore ?? new FileDataStore(Folder);
+            initializer.IncludeGrantedScopes = includeGrantedScopes;
             var flow = new GoogleAuthorizationCodeFlow(initializer);
 
             // Create an authorization code installed app instance and authorize the user.
-            return await new AuthorizationCodeInstalledApp(flow, new LocalServerCodeReceiver()).AuthorizeAsync
-                (user, taskCancellationToken).ConfigureAwait(false);
+            return await new AuthorizationCodeInstalledApp(flow, new LocalServerCodeReceiver())
+                .AuthorizeAsync(user, taskCancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/Src/GoogleApis.Auth/OAuth2/AuthorizationCodeInstalledApp.cs
+++ b/Src/GoogleApis.Auth/OAuth2/AuthorizationCodeInstalledApp.cs
@@ -64,7 +64,7 @@ namespace Google.Apis.Auth.OAuth2
 
             // If the stored token is null or it doesn't have a refresh token and the access token is expired we need 
             // to retrieve a new authorization code.
-            if (token == null || (token.RefreshToken == null && token.IsExpired(flow.Clock)))
+            if (token == null || Flow.ShouldForceTokenRetrieval() || (token.RefreshToken == null && token.IsExpired(flow.Clock)))
             {
                 // Create an authorization code request.
                 var redirectUri = CodeReceiver.RedirectUri;

--- a/Src/GoogleApis.Auth/OAuth2/AuthorizationCodeInstalledApp.cs
+++ b/Src/GoogleApis.Auth/OAuth2/AuthorizationCodeInstalledApp.cs
@@ -87,7 +87,7 @@ namespace Google.Apis.Auth.OAuth2
                     taskCancellationToken).ConfigureAwait(false);
             }
 
-            return new UserCredential(Flow, userId, token);
+            return new UserCredential(flow, userId, token);
         }
 
         /// <summary>
@@ -98,7 +98,8 @@ namespace Google.Apis.Auth.OAuth2
         {
             // If the flow includes a parameter that requires a new token, if the stored token is null or it doesn't
             // have a refresh token and the access token is expired we need to retrieve a new authorization code.
-            return Flow.ShouldForceTokenRetrieval() || token == null || (token.RefreshToken == null && token.IsExpired(flow.Clock));
+            return Flow.ShouldForceTokenRetrieval() || token == null || (token.RefreshToken == null 
+                && token.IsExpired(flow.Clock));
         }
 
         #endregion

--- a/Src/GoogleApis.Auth/OAuth2/AuthorizationCodeInstalledApp.cs
+++ b/Src/GoogleApis.Auth/OAuth2/AuthorizationCodeInstalledApp.cs
@@ -26,6 +26,7 @@ namespace Google.Apis.Auth.OAuth2
 {
     /// <summary>
     /// Thread-safe OAuth 2.0 authorization code flow for an installed application that persists end-user credentials.
+    /// Incremental authorization is not supported for installed app authorization.
     /// </summary>
     public class AuthorizationCodeInstalledApp : IAuthorizationCodeInstalledApp
     {

--- a/Src/GoogleApis.Auth/OAuth2/AuthorizationCodeInstalledApp.cs
+++ b/Src/GoogleApis.Auth/OAuth2/AuthorizationCodeInstalledApp.cs
@@ -64,7 +64,7 @@ namespace Google.Apis.Auth.OAuth2
 
             // If the stored token is null or it doesn't have a refresh token and the access token is expired we need 
             // to retrieve a new authorization code.
-            if (token == null || Flow.ShouldForceTokenRetrieval() || (token.RefreshToken == null && token.IsExpired(flow.Clock)))
+            if (Flow.ShouldForceTokenRetrieval() || token == null || (token.RefreshToken == null && token.IsExpired(flow.Clock)))
             {
                 // Create an authorization code request.
                 var redirectUri = CodeReceiver.RedirectUri;

--- a/Src/GoogleApis.Auth/OAuth2/AuthorizationCodeInstalledApp.cs
+++ b/Src/GoogleApis.Auth/OAuth2/AuthorizationCodeInstalledApp.cs
@@ -26,8 +26,11 @@ namespace Google.Apis.Auth.OAuth2
 {
     /// <summary>
     /// Thread-safe OAuth 2.0 authorization code flow for an installed application that persists end-user credentials.
-    /// Incremental authorization is not supported for installed app authorization.
     /// </summary>
+    /// <remarks>
+    /// Incremental authorization (https://developers.google.com/+/web/api/rest/oauth) is currently not supported
+    /// for Installed Apps.
+    /// </remarks>
     public class AuthorizationCodeInstalledApp : IAuthorizationCodeInstalledApp
     {
         private static readonly ILogger Logger = ApplicationContext.Logger.ForType<AuthorizationCodeInstalledApp>();
@@ -63,7 +66,7 @@ namespace Google.Apis.Auth.OAuth2
             // Try to load a token from the data store.
             var token = await Flow.LoadTokenAsync(userId, taskCancellationToken).ConfigureAwait(false);
 
-            //Check if a new authorization code is needed.
+            // Check if a new authorization code is needed.
             if (ShouldRequestAuthorizationCode(token))
             {
                 // Create an authorization code request.
@@ -97,6 +100,7 @@ namespace Google.Apis.Auth.OAuth2
         /// </summary>
         public bool ShouldRequestAuthorizationCode(TokenResponse token)
         {
+            // TODO: This code should be shared between this class and AuthorizationCodeWebApp.
             // If the flow includes a parameter that requires a new token, if the stored token is null or it doesn't
             // have a refresh token and the access token is expired we need to retrieve a new authorization code.
             return Flow.ShouldForceTokenRetrieval() || token == null || (token.RefreshToken == null 

--- a/Src/GoogleApis.Auth/OAuth2/AuthorizationCodeInstalledApp.cs
+++ b/Src/GoogleApis.Auth/OAuth2/AuthorizationCodeInstalledApp.cs
@@ -62,9 +62,8 @@ namespace Google.Apis.Auth.OAuth2
             // Try to load a token from the data store.
             var token = await Flow.LoadTokenAsync(userId, taskCancellationToken).ConfigureAwait(false);
 
-            // If the stored token is null or it doesn't have a refresh token and the access token is expired we need 
-            // to retrieve a new authorization code.
-            if (Flow.ShouldForceTokenRetrieval() || token == null || (token.RefreshToken == null && token.IsExpired(flow.Clock)))
+            //Check if a new authorization code is needed.
+            if (ShouldRequestAuthorizationCode(token))
             {
                 // Create an authorization code request.
                 var redirectUri = CodeReceiver.RedirectUri;
@@ -88,7 +87,18 @@ namespace Google.Apis.Auth.OAuth2
                     taskCancellationToken).ConfigureAwait(false);
             }
 
-            return new UserCredential(flow, userId, token);
+            return new UserCredential(Flow, userId, token);
+        }
+
+        /// <summary>
+        /// Determines the need for retrieval of a new authorization code, based on the given token and the 
+        /// authorization code flow.
+        /// </summary>
+        public bool ShouldRequestAuthorizationCode(TokenResponse token)
+        {
+            // If the flow includes a parameter that requires a new token, if the stored token is null or it doesn't
+            // have a refresh token and the access token is expired we need to retrieve a new authorization code.
+            return Flow.ShouldForceTokenRetrieval() || token == null || (token.RefreshToken == null && token.IsExpired(flow.Clock));
         }
 
         #endregion

--- a/Src/GoogleApis.Auth/OAuth2/Flows/AuthorizationCodeFlow.cs
+++ b/Src/GoogleApis.Auth/OAuth2/Flows/AuthorizationCodeFlow.cs
@@ -270,6 +270,7 @@ namespace Google.Apis.Auth.OAuth2.Flows
             throw new NotImplementedException("The OAuth 2.0 protocol does not support token revocation.");
         }
 
+        public virtual bool ShouldForceTokenRetrieval() { return false; }
         #endregion
 
         /// <summary>Stores the token in the <see cref="DataStore"/>.</summary>

--- a/Src/GoogleApis.Auth/OAuth2/Flows/AuthorizationCodeFlow.cs
+++ b/Src/GoogleApis.Auth/OAuth2/Flows/AuthorizationCodeFlow.cs
@@ -271,6 +271,7 @@ namespace Google.Apis.Auth.OAuth2.Flows
         }
 
         public virtual bool ShouldForceTokenRetrieval() { return false; }
+
         #endregion
 
         /// <summary>Stores the token in the <see cref="DataStore"/>.</summary>

--- a/Src/GoogleApis.Auth/OAuth2/Flows/GoogleAuthorizationCodeFlow.cs
+++ b/Src/GoogleApis.Auth/OAuth2/Flows/GoogleAuthorizationCodeFlow.cs
@@ -80,12 +80,7 @@ namespace Google.Apis.Auth.OAuth2.Flows
 
         public override bool ShouldForceTokenRetrieval() 
         {
-            if (includeGrantedScopes.HasValue && includeGrantedScopes.Value == true)
-            {
-                return true;
-            }
-
-            return false;
+            return includeGrantedScopes.HasValue && includeGrantedScopes.Value == true;
         }
 
         /// <summary>An initializer class for Google authorization code flow. </summary>

--- a/Src/GoogleApis.Auth/OAuth2/Flows/GoogleAuthorizationCodeFlow.cs
+++ b/Src/GoogleApis.Auth/OAuth2/Flows/GoogleAuthorizationCodeFlow.cs
@@ -78,13 +78,23 @@ namespace Google.Apis.Auth.OAuth2.Flows
             await DeleteTokenAsync(userId, taskCancellationToken);
         }
 
+        public override bool ShouldForceTokenRetrieval() 
+        {
+            if (includeGrantedScopes.HasValue && includeGrantedScopes.Value == true)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
         /// <summary>An initializer class for Google authorization code flow. </summary>
         public new class Initializer : AuthorizationCodeFlow.Initializer
         {
             /// <summary>Gets or sets the token revocation URL.</summary>
             public string RevokeTokenUrl { get; set; }
 
-            /// <summary>Gets or sets the indicator for including granted scopes for incremental authorization.</summary>
+            /// <summary>Gets or sets the optional indicator for including granted scopes for incremental authorization.</summary>
             public bool? IncludeGrantedScopes { get; set; }
 
             /// <summary>

--- a/Src/GoogleApis.Auth/OAuth2/Flows/GoogleAuthorizationCodeFlow.cs
+++ b/Src/GoogleApis.Auth/OAuth2/Flows/GoogleAuthorizationCodeFlow.cs
@@ -53,7 +53,7 @@ namespace Google.Apis.Auth.OAuth2.Flows
                 ClientId = ClientSecrets.ClientId,
                 Scope = string.Join(" ", Scopes),
                 RedirectUri = redirectUri,
-                IncludeGrantedScopes = (includeGrantedScopes.HasValue)
+                IncludeGrantedScopes = includeGrantedScopes.HasValue
                     ? includeGrantedScopes.Value.ToString().ToLower() : null
             };
         }
@@ -80,7 +80,7 @@ namespace Google.Apis.Auth.OAuth2.Flows
 
         public override bool ShouldForceTokenRetrieval() 
         {
-            return includeGrantedScopes.HasValue && includeGrantedScopes.Value == true;
+            return includeGrantedScopes.HasValue && includeGrantedScopes.Value;
         }
 
         /// <summary>An initializer class for Google authorization code flow. </summary>

--- a/Src/GoogleApis.Auth/OAuth2/Flows/GoogleAuthorizationCodeFlow.cs
+++ b/Src/GoogleApis.Auth/OAuth2/Flows/GoogleAuthorizationCodeFlow.cs
@@ -35,8 +35,10 @@ namespace Google.Apis.Auth.OAuth2.Flows
         /// <summary>Gets the token revocation URL.</summary>
         public string RevokeTokenUrl { get { return revokeTokenUrl; } }
 
+        public readonly bool? includeGrantedScopes;
+
         /// <summary>Gets or sets the include granted scopes indicator.</summary>
-        private bool? includeGrantedScopes { get; set; }
+        public bool? IncludeGrantedScopes { get { return includeGrantedScopes; } }
 
         /// <summary>Constructs a new Google authorization code flow.</summary>
         public GoogleAuthorizationCodeFlow(Initializer initializer)
@@ -53,8 +55,8 @@ namespace Google.Apis.Auth.OAuth2.Flows
                 ClientId = ClientSecrets.ClientId,
                 Scope = string.Join(" ", Scopes),
                 RedirectUri = redirectUri,
-                IncludeGrantedScopes = includeGrantedScopes.HasValue
-                    ? includeGrantedScopes.Value.ToString().ToLower() : null
+                IncludeGrantedScopes = IncludeGrantedScopes.HasValue
+                    ? IncludeGrantedScopes.Value.ToString().ToLower() : null
             };
         }
 
@@ -80,7 +82,7 @@ namespace Google.Apis.Auth.OAuth2.Flows
 
         public override bool ShouldForceTokenRetrieval() 
         {
-            return includeGrantedScopes.HasValue && includeGrantedScopes.Value;
+            return IncludeGrantedScopes.HasValue && IncludeGrantedScopes.Value;
         }
 
         /// <summary>An initializer class for Google authorization code flow. </summary>

--- a/Src/GoogleApis.Auth/OAuth2/Flows/GoogleAuthorizationCodeFlow.cs
+++ b/Src/GoogleApis.Auth/OAuth2/Flows/GoogleAuthorizationCodeFlow.cs
@@ -35,11 +35,15 @@ namespace Google.Apis.Auth.OAuth2.Flows
         /// <summary>Gets the token revocation URL.</summary>
         public string RevokeTokenUrl { get { return revokeTokenUrl; } }
 
+        /// <summary>Gets or sets the include granted scopes indicator.</summary>
+        private bool? includeGrantedScopes { get; set; }
+
         /// <summary>Constructs a new Google authorization code flow.</summary>
         public GoogleAuthorizationCodeFlow(Initializer initializer)
             : base(initializer)
         {
             revokeTokenUrl = initializer.RevokeTokenUrl;
+            includeGrantedScopes = initializer.IncludeGrantedScopes;
         }
 
         public override AuthorizationCodeRequestUrl CreateAuthorizationCodeRequest(string redirectUri)
@@ -48,7 +52,9 @@ namespace Google.Apis.Auth.OAuth2.Flows
             {
                 ClientId = ClientSecrets.ClientId,
                 Scope = string.Join(" ", Scopes),
-                RedirectUri = redirectUri
+                RedirectUri = redirectUri,
+                IncludeGrantedScopes = (includeGrantedScopes.HasValue)
+                    ? includeGrantedScopes.Value.ToString().ToLower() : null
             };
         }
 
@@ -77,6 +83,9 @@ namespace Google.Apis.Auth.OAuth2.Flows
         {
             /// <summary>Gets or sets the token revocation URL.</summary>
             public string RevokeTokenUrl { get; set; }
+
+            /// <summary>Gets or sets the indicator for including granted scopes for incremental authorization.</summary>
+            public bool? IncludeGrantedScopes { get; set; }
 
             /// <summary>
             /// Constructs a new initializer. Sets Authorization server URL to 

--- a/Src/GoogleApis.Auth/OAuth2/Flows/IAuthorizationCodeFlow.cs
+++ b/Src/GoogleApis.Auth/OAuth2/Flows/IAuthorizationCodeFlow.cs
@@ -86,5 +86,11 @@ namespace Google.Apis.Auth.OAuth2.Flows
         /// <param name="taskCancellationToken">Cancellation token to cancel operation.</param>
         /// <returns><c>true</c> if the token was revoked successfully.</returns>        
         Task RevokeTokenAsync(string userId, string token, CancellationToken taskCancellationToken);
+
+        /// <summary>
+        /// Indicates if a new token needs to be retrieved and stored regardless of normal circumstances.
+        /// </summary>
+        /// <returns></returns>
+        bool ShouldForceTokenRetrieval();
     }
 }

--- a/Src/GoogleApis.Auth/OAuth2/Flows/IAuthorizationCodeFlow.cs
+++ b/Src/GoogleApis.Auth/OAuth2/Flows/IAuthorizationCodeFlow.cs
@@ -90,7 +90,6 @@ namespace Google.Apis.Auth.OAuth2.Flows
         /// <summary>
         /// Indicates if a new token needs to be retrieved and stored regardless of normal circumstances.
         /// </summary>
-        /// <returns></returns>
         bool ShouldForceTokenRetrieval();
     }
 }

--- a/Src/GoogleApis.Auth/OAuth2/Requests/GoogleAuthorizationCodeRequestUrl.cs
+++ b/Src/GoogleApis.Auth/OAuth2/Requests/GoogleAuthorizationCodeRequestUrl.cs
@@ -54,7 +54,8 @@ namespace Google.Apis.Auth.OAuth2.Requests
         /// If true and the authorization request is granted, the authorization will include any previous 
         /// authorizations granted to this user/application combination for other scopes.
         /// </summary>
-        [Google.Apis.Util.RequestParameterAttribute("include_granted_scopes", Google.Apis.Util.RequestParameterType.Query)]
+        [Google.Apis.Util.RequestParameterAttribute("include_granted_scopes",
+            Google.Apis.Util.RequestParameterType.Query)]
         public string IncludeGrantedScopes { get; set; }
 
         /// <summary>

--- a/Src/GoogleApis.Auth/OAuth2/Requests/GoogleAuthorizationCodeRequestUrl.cs
+++ b/Src/GoogleApis.Auth/OAuth2/Requests/GoogleAuthorizationCodeRequestUrl.cs
@@ -54,7 +54,7 @@ namespace Google.Apis.Auth.OAuth2.Requests
         /// If true and the authorization request is granted, the authorization will include any previous 
         /// authorizations granted to this user/application combination for other scopes.
         /// </summary>
-        /// <remarks> Currently unsupported for installed apps. </remarks>
+        /// <remarks>Currently unsupported for installed apps.</remarks>
         [Google.Apis.Util.RequestParameterAttribute("include_granted_scopes",
             Google.Apis.Util.RequestParameterType.Query)]
         public string IncludeGrantedScopes { get; set; }

--- a/Src/GoogleApis.Auth/OAuth2/Requests/GoogleAuthorizationCodeRequestUrl.cs
+++ b/Src/GoogleApis.Auth/OAuth2/Requests/GoogleAuthorizationCodeRequestUrl.cs
@@ -54,7 +54,7 @@ namespace Google.Apis.Auth.OAuth2.Requests
         /// If true and the authorization request is granted, the authorization will include any previous 
         /// authorizations granted to this user/application combination for other scopes.
         /// </summary>
-        /// <remarks>Currently unsupported for installed apps. </remarks>
+        /// <remarks> Currently unsupported for installed apps. </remarks>
         [Google.Apis.Util.RequestParameterAttribute("include_granted_scopes",
             Google.Apis.Util.RequestParameterType.Query)]
         public string IncludeGrantedScopes { get; set; }

--- a/Src/GoogleApis.Auth/OAuth2/Requests/GoogleAuthorizationCodeRequestUrl.cs
+++ b/Src/GoogleApis.Auth/OAuth2/Requests/GoogleAuthorizationCodeRequestUrl.cs
@@ -33,7 +33,7 @@ namespace Google.Apis.Auth.OAuth2.Requests
         public string AccessType { get; set; }
 
         /// <summary>
-        /// Gets pr sets prompt for consent behavior <c>auto</c> to request auto-approval or<c>force</c> to force the 
+        /// Gets or sets prompt for consent behavior <c>auto</c> to request auto-approval or<c>force</c> to force the 
         /// approval UI to show, or <c>null</c> for the default behavior.
         /// </summary>
         [Google.Apis.Util.RequestParameterAttribute("approval_prompt", Google.Apis.Util.RequestParameterType.Query)]

--- a/Src/GoogleApis.Auth/OAuth2/Requests/GoogleAuthorizationCodeRequestUrl.cs
+++ b/Src/GoogleApis.Auth/OAuth2/Requests/GoogleAuthorizationCodeRequestUrl.cs
@@ -52,9 +52,9 @@ namespace Google.Apis.Auth.OAuth2.Requests
         /// Gets or sets the include granted scopes to determine if this authorization request should use
         /// incremental authorization (https://developers.google.com/+/web/api/rest/oauth#incremental-auth).
         /// If true and the authorization request is granted, the authorization will include any previous 
-        /// authorizations granted to this user/application combination for other scopes. Currently unsupported
-        /// for installed apps.
+        /// authorizations granted to this user/application combination for other scopes.
         /// </summary>
+        /// <remarks>Currently unsupported for installed apps. </remarks>
         [Google.Apis.Util.RequestParameterAttribute("include_granted_scopes",
             Google.Apis.Util.RequestParameterType.Query)]
         public string IncludeGrantedScopes { get; set; }

--- a/Src/GoogleApis.Auth/OAuth2/Requests/GoogleAuthorizationCodeRequestUrl.cs
+++ b/Src/GoogleApis.Auth/OAuth2/Requests/GoogleAuthorizationCodeRequestUrl.cs
@@ -52,7 +52,8 @@ namespace Google.Apis.Auth.OAuth2.Requests
         /// Gets or sets the include granted scopes to determine if this authorization request should use
         /// incremental authorization (https://developers.google.com/+/web/api/rest/oauth#incremental-auth).
         /// If true and the authorization request is granted, the authorization will include any previous 
-        /// authorizations granted to this user/application combination for other scopes.
+        /// authorizations granted to this user/application combination for other scopes. Currently unsupported
+        /// for installed apps.
         /// </summary>
         [Google.Apis.Util.RequestParameterAttribute("include_granted_scopes",
             Google.Apis.Util.RequestParameterType.Query)]

--- a/Src/GoogleApis.Auth/OAuth2/Requests/GoogleAuthorizationCodeRequestUrl.cs
+++ b/Src/GoogleApis.Auth/OAuth2/Requests/GoogleAuthorizationCodeRequestUrl.cs
@@ -49,11 +49,11 @@ namespace Google.Apis.Auth.OAuth2.Requests
         public string LoginHint { get; set; }
 
         /// <summary>
-        /// Gets or sets the Include Granted Scopes to determine if this authorization request should use
-        /// incremental authorization. If this is provided with the value <c>true</c>, and the authorization 
-        /// request is granted, the authorization will include any previous authorizations granted to this 
-        /// user/application combination for other scopes. Default value is <c>false</c> and will be omitted
-        /// unless explicitly indicated.
+        /// Gets or sets the include granted scopes to determine if this authorization request should use
+        /// incremental authorization (https://developers.google.com/+/web/api/rest/oauth#incremental-auth).
+        /// If this is provided with the value <c>true</c>, and the authorization request is granted, the 
+        /// authorization will include any previous authorizations granted to this user/application combination 
+        /// for other scopes. Default value is <c>false</c> and will be omitted unless explicitly indicated.
         /// </summary>
         [Google.Apis.Util.RequestParameterAttribute("include_granted_scopes", Google.Apis.Util.RequestParameterType.Query)]
         public string IncludeGrantedScopes { get; set; }
@@ -66,7 +66,6 @@ namespace Google.Apis.Auth.OAuth2.Requests
             : base(authorizationServerUrl)
         {
             AccessType = "offline";
-            IncludeGrantedScopes = null;
         }
     }
 }

--- a/Src/GoogleApis.Auth/OAuth2/Requests/GoogleAuthorizationCodeRequestUrl.cs
+++ b/Src/GoogleApis.Auth/OAuth2/Requests/GoogleAuthorizationCodeRequestUrl.cs
@@ -51,9 +51,9 @@ namespace Google.Apis.Auth.OAuth2.Requests
         /// <summary>
         /// Gets or sets the include granted scopes to determine if this authorization request should use
         /// incremental authorization (https://developers.google.com/+/web/api/rest/oauth#incremental-auth).
-        /// If this is provided with the value <c>true</c>, and the authorization request is granted, the 
-        /// authorization will include any previous authorizations granted to this user/application combination 
-        /// for other scopes. Default value is <c>false</c> and will be omitted unless explicitly indicated.
+        /// If true and the authorization request is granted, the authorization will include any previous 
+        /// authorizations granted to this user/application combination for other scopes. Default value is 
+        /// false and will be omitted unless explicitly indicated.
         /// </summary>
         [Google.Apis.Util.RequestParameterAttribute("include_granted_scopes", Google.Apis.Util.RequestParameterType.Query)]
         public string IncludeGrantedScopes { get; set; }

--- a/Src/GoogleApis.Auth/OAuth2/Requests/GoogleAuthorizationCodeRequestUrl.cs
+++ b/Src/GoogleApis.Auth/OAuth2/Requests/GoogleAuthorizationCodeRequestUrl.cs
@@ -49,6 +49,16 @@ namespace Google.Apis.Auth.OAuth2.Requests
         public string LoginHint { get; set; }
 
         /// <summary>
+        /// Gets or sets the Include Granted Scopes to determine if this authorization request should use
+        /// incremental authorization. If this is provided with the value <c>true</c>, and the authorization 
+        /// request is granted, the authorization will include any previous authorizations granted to this 
+        /// user/application combination for other scopes. Default value is <c>false</c> and will be omitted
+        /// unless explicitly indicated.
+        /// </summary>
+        [Google.Apis.Util.RequestParameterAttribute("include_granted_scopes", Google.Apis.Util.RequestParameterType.Query)]
+        public string IncludeGrantedScopes { get; set; }
+
+        /// <summary>
         /// Constructs a new authorization code request with the given authorization server URL. This constructor sets
         /// the <see cref="AccessType"/> to <c>offline</c>.
         /// </summary>
@@ -56,6 +66,7 @@ namespace Google.Apis.Auth.OAuth2.Requests
             : base(authorizationServerUrl)
         {
             AccessType = "offline";
+            IncludeGrantedScopes = null;
         }
     }
 }

--- a/Src/GoogleApis.Auth/OAuth2/Requests/GoogleAuthorizationCodeRequestUrl.cs
+++ b/Src/GoogleApis.Auth/OAuth2/Requests/GoogleAuthorizationCodeRequestUrl.cs
@@ -52,8 +52,7 @@ namespace Google.Apis.Auth.OAuth2.Requests
         /// Gets or sets the include granted scopes to determine if this authorization request should use
         /// incremental authorization (https://developers.google.com/+/web/api/rest/oauth#incremental-auth).
         /// If true and the authorization request is granted, the authorization will include any previous 
-        /// authorizations granted to this user/application combination for other scopes. Default value is 
-        /// false and will be omitted unless explicitly indicated.
+        /// authorizations granted to this user/application combination for other scopes.
         /// </summary>
         [Google.Apis.Util.RequestParameterAttribute("include_granted_scopes", Google.Apis.Util.RequestParameterType.Query)]
         public string IncludeGrantedScopes { get; set; }

--- a/Src/GoogleApis.Auth/OAuth2/Web/AuthorizationCodeWebApp.cs
+++ b/Src/GoogleApis.Auth/OAuth2/Web/AuthorizationCodeWebApp.cs
@@ -19,6 +19,7 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using Google.Apis.Auth.OAuth2.Flows;
+using Google.Apis.Auth.OAuth2.Responses;
 using Google.Apis.Auth.OAuth2.Requests;
 
 namespace Google.Apis.Auth.OAuth2.Web
@@ -102,7 +103,7 @@ namespace Google.Apis.Auth.OAuth2.Web
 
             // If the stored token is null or it doesn't have a refresh token and the access token is expired, we need 
             // to retrieve a new access token.
-            if (token == null || (token.RefreshToken == null && token.IsExpired(flow.Clock)))
+            if (ShouldRequestAuthorizationCode(token))
             {
                 // Create an authorization code request.
                 AuthorizationCodeRequestUrl codeRequest = Flow.CreateAuthorizationCodeRequest(redirectUri);
@@ -123,6 +124,18 @@ namespace Google.Apis.Auth.OAuth2.Web
             }
 
             return new AuthResult { Credential = new UserCredential(flow, userId, token) };
+        }
+
+        /// <summary>
+        /// Determines the need for retrieval of a new authorization code, based on the given token and the 
+        /// authorization code flow.
+        /// </summary>
+        public bool ShouldRequestAuthorizationCode(TokenResponse token)
+        {
+            // If the flow includes a parameter that requires a new token, if the stored token is null or it doesn't
+            // have a refresh token and the access token is expired we need to retrieve a new authorization code.
+            return Flow.ShouldForceTokenRetrieval() || token == null || (token.RefreshToken == null
+                && token.IsExpired(flow.Clock));
         }
     }
 }

--- a/Src/GoogleApis.Auth/OAuth2/Web/AuthorizationCodeWebApp.cs
+++ b/Src/GoogleApis.Auth/OAuth2/Web/AuthorizationCodeWebApp.cs
@@ -101,8 +101,7 @@ namespace Google.Apis.Auth.OAuth2.Web
             // Try to load a token from the data store.
             var token = await Flow.LoadTokenAsync(userId, taskCancellationToken).ConfigureAwait(false);
 
-            // If the stored token is null or it doesn't have a refresh token and the access token is expired, we need 
-            // to retrieve a new access token.
+            // Check if a new authorization code is needed.
             if (ShouldRequestAuthorizationCode(token))
             {
                 // Create an authorization code request.
@@ -132,6 +131,7 @@ namespace Google.Apis.Auth.OAuth2.Web
         /// </summary>
         public bool ShouldRequestAuthorizationCode(TokenResponse token)
         {
+            // TODO: This code should be shared between this class and AuthorizationCodeInstalledApp.
             // If the flow includes a parameter that requires a new token, if the stored token is null or it doesn't
             // have a refresh token and the access token is expired we need to retrieve a new authorization code.
             return Flow.ShouldForceTokenRetrieval() || token == null || (token.RefreshToken == null

--- a/Src/GoogleApis.Auth/OAuth2/Web/AuthorizationCodeWebApp.cs
+++ b/Src/GoogleApis.Auth/OAuth2/Web/AuthorizationCodeWebApp.cs
@@ -19,8 +19,8 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using Google.Apis.Auth.OAuth2.Flows;
-using Google.Apis.Auth.OAuth2.Responses;
 using Google.Apis.Auth.OAuth2.Requests;
+using Google.Apis.Auth.OAuth2.Responses;
 
 namespace Google.Apis.Auth.OAuth2.Web
 {

--- a/Src/GoogleApis.Core/Apis/Http/HttpClientFactory.cs
+++ b/Src/GoogleApis.Core/Apis/Http/HttpClientFactory.cs
@@ -54,7 +54,7 @@ namespace Google.Apis.Http
         {
             var handler = new HttpClientHandler();
 
-            // If the framework supports redirect configuration, set it to false, because ConfigurableMessageHnalder 
+            // If the framework supports redirect configuration, set it to false, because ConfigurableMessageHandler 
             // handles redirect.
             if (handler.SupportsRedirectConfiguration)
             {


### PR DESCRIPTION
This adds support of the library to authenticate with the [```include_granted_scopes```](https://developers.google.com/identity/protocols/OAuth2InstalledApp#incrementalAuth) parameter which [does not currently exist](http://stackoverflow.com/questions/33470699/how-to-implement-incremental-authorization-with-google-api#comment54766478_33470699).

Usage is intended to be exposed to a user of the library who is already using ```GoogleWebAuthorizationBroker.AuthorizeAsync()``` by adding a single new parameter - ```includeGrantedScopes``` - which is a nullable bool and set to null by default. For example:

```
userCredentials = await GoogleWebAuthorizationBroker.AuthorizeAsync(
                    MyClientSecrets, scopes, userName,
                    System.Threading.CancellationToken.None, new DataStore(),
                    true //this will set the include_granted_scopes=true in the url
                    );
```

If the user omits this optional parameter the null is trickled down and is ignored when building the authorization request URL (thereby defaulting to false in the request). When explicitly included, the query parameter is included in the URL with the value supplied, even if false.

I have tested it up to the point of verifying that it creates the url with the appropriate query parameters as expected, and ensured that the URL resolves and supplies an appropriate authentication page in the browser. I have not been able to test the resulting tokens however due to my applications being all installed applications at this time, which do not work with [Incremental Authorization](http://stackoverflow.com/questions/33514722/how-to-supply-scopes-as-part-of-post-body-rather-than-url-params/33516367?noredirect=1#comment54831247_33516367) to my knowledge.

A proper test could likely be set up to ensure that the resulting url contains the parameter when expected, however I haven't fully wrapped my head around the mocking setup used in the project's tests. If someone would be willing to guide me through it I'd be more than happy to work on that as well, though my experience with tests is somewhat limited.

This also fixes two minor typos I came across for which I saw no need for a separate pull request. It's also my first pull request, so please let me know if I have done something incorrectly during the process.