### PR TITLE
Only request read access to the file when opening the stream.

### DIFF
--- a/Src/GoogleApis.Auth.DotNet4/OAuth2/DefaultCredentialProvider.cs
+++ b/Src/GoogleApis.Auth.DotNet4/OAuth2/DefaultCredentialProvider.cs
@@ -268,7 +268,7 @@ namespace Google.Apis.Auth.OAuth2
         /// </summary>
         protected virtual Stream GetStream(string filePath)
         {
-            return new FileStream(filePath, FileMode.Open);
+            return new FileStream(filePath, FileMode.Open, FileAccess.Read);
         }
     }
 }


### PR DESCRIPTION
Since the library is only reading from the stream it can request read-only access to it, which will make it not interfere with other tools reading the credentials file and make it possible to run on read only file systems, such as one shared on a Docker container.
