### PR TITLE
Fix media upload/download error handling

### DIFF
--- a/Src/GoogleApis.Tests/Apis/Download/MediaDownloaderTest.cs
+++ b/Src/GoogleApis.Tests/Apis/Download/MediaDownloaderTest.cs
@@ -28,7 +28,10 @@ using System.Threading.Tasks;
 using NUnit.Framework;
 
 using Google.Apis.Download;
+using Google.Apis.Json;
 using Google.Apis.Services;
+using Google.Apis.Requests;
+using Google.Apis.Util;
 
 namespace Google.Apis.Tests.Apis.Download
 {
@@ -37,22 +40,7 @@ namespace Google.Apis.Tests.Apis.Download
     class MediaDownloaderTest
     {
         /// <summary>The content the "server" uses to send to the client.</summary>
-        static string MediaContent = @"Media content goes here. This is an example of test content.";
-
-        /// <summary>The stream the "server" uses to send to the client.</summary>
-        static Stream StreamContent;
-
-        [TestFixtureSetUp]
-        public static void AllTestsSetUp()
-        {
-            StreamContent = new MemoryStream(Encoding.UTF8.GetBytes(MediaContent));
-        }
-
-        [TestFixtureTearDown]
-        public static void AllTestsTearDown()
-        {
-            StreamContent.Dispose();
-        }
+        private static readonly byte[] MediaContent = Encoding.UTF8.GetBytes("Media content goes here. This is an example of test content.");
 
         /// <summary> An handler which demonstrate a client download which contains multiple chunks. </summary>
         private class MultipleChunksMessageHandler : CountableMessageHandler
@@ -72,8 +60,30 @@ namespace Google.Apis.Tests.Apis.Download
             /// <summary>Gets or sets the download Uri.</summary>
             public Uri DownloadUri { get; set; }
 
+            /// <summary>Content to stream for success requests.</summary>
+            internal Stream StreamContent { get; set; }
+
+            /// <summary>Content to return (in UTF-8) for error requests.</summary>
+            internal string ErrorResponse { get; set; }
+
             /// <summary>The number of bytes this "server" has sent so far.</summary>
             private long bytesRead;
+
+            /// <summary>
+            /// Constructor which uses the given content for StreamContent.
+            /// </summary>
+            internal MultipleChunksMessageHandler(byte[] content)
+            {
+                StreamContent = new MemoryStream(content);
+            }
+
+            /// <summary>
+            /// Constructor which sets StreamContent to an initially-empty stream.
+            /// </summary>
+            internal MultipleChunksMessageHandler()
+            {
+                StreamContent = new MemoryStream();
+            }
 
             protected override Task<HttpResponseMessage> SendAsyncCore(HttpRequestMessage request,
                 CancellationToken cancellationToken)
@@ -109,6 +119,10 @@ namespace Google.Apis.Tests.Apis.Download
 
                     bytesRead += currentRead;
                 }
+                else
+                {
+                    response.Content = new StreamContent(new MemoryStream(Encoding.UTF8.GetBytes(ErrorResponse)));
+                }
                 tcs.SetResult(response);
                 return tcs.Task;
             }
@@ -119,15 +133,15 @@ namespace Google.Apis.Tests.Apis.Download
         public void Download_MultipleChunks()
         {
             Subtest_Download_Chunks(2);
-            Subtest_Download_Chunks((int)StreamContent.Length - 1);
+            Subtest_Download_Chunks(MediaContent.Length - 1);
         }
 
         /// <summary>Tests that download works in case the server returns a single chunk to the client.</summary>
         [Test]
         public void Download_SingleChunk()
         {
-            Subtest_Download_Chunks((int)StreamContent.Length);
-            Subtest_Download_Chunks((int)StreamContent.Length + 1);
+            Subtest_Download_Chunks(MediaContent.Length);
+            Subtest_Download_Chunks(MediaContent.Length + 1);
             Subtest_Download_Chunks(100);
         }
 
@@ -135,21 +149,21 @@ namespace Google.Apis.Tests.Apis.Download
         [Test]
         public void Download_SingleChunk_UriContainsQueryParameters()
         {
-            Subtest_Download_Chunks((int)StreamContent.Length, true, 0, "https://www.sample.com?a=1&b=2");
+            Subtest_Download_Chunks(MediaContent.Length, true, 0, "https://www.sample.com?a=1&b=2");
         }
 
         /// <summary>Tests that download works in case the URI download contains query parameters.</summary>
         [Test]
         public void Download_SingleChunk_UriContainsEncodedQueryParameters()
         {
-            Subtest_Download_Chunks((int)StreamContent.Length, true, 0, "https://www.sample.com?a=foo%2Fbar");
+            Subtest_Download_Chunks(MediaContent.Length, true, 0, "https://www.sample.com?a=foo%2Fbar");
         }
 
         /// <summary>Tests that download works in case the URI download contains query parameters.</summary>
         [Test]
         public void Download_SingleChunk_UriContainsValuelessQueryParameters()
         {
-            Subtest_Download_Chunks((int)StreamContent.Length, true, 0, "https://www.sample.com?a&b=1");
+            Subtest_Download_Chunks(MediaContent.Length, true, 0, "https://www.sample.com?a&b=1");
         }
 
         /// <summary>
@@ -159,7 +173,7 @@ namespace Google.Apis.Tests.Apis.Download
         public void DownloadAsync_MultipleChunks()
         {
             Subtest_Download_Chunks(2, false);
-            Subtest_Download_Chunks((int)StreamContent.Length - 1, false);
+            Subtest_Download_Chunks(MediaContent.Length - 1, false);
         }
 
         /// <summary>
@@ -168,8 +182,8 @@ namespace Google.Apis.Tests.Apis.Download
         [Test]
         public void DownloadAsync_SingleChunk()
         {
-            Subtest_Download_Chunks((int)StreamContent.Length, false);
-            Subtest_Download_Chunks((int)StreamContent.Length + 1, false);
+            Subtest_Download_Chunks(MediaContent.Length, false);
+            Subtest_Download_Chunks(MediaContent.Length + 1, false);
             Subtest_Download_Chunks(100, false);
         }
 
@@ -180,7 +194,7 @@ namespace Google.Apis.Tests.Apis.Download
         public void DownloadAsync_Cancel()
         {
             Subtest_Download_Chunks(2, false, 3);
-            Subtest_Download_Chunks((int)StreamContent.Length - 1, false, 1);
+            Subtest_Download_Chunks(MediaContent.Length - 1, false, 1);
         }
 
         /// <summary>A helper test to test sync and async downloads.</summary>
@@ -191,10 +205,7 @@ namespace Google.Apis.Tests.Apis.Download
         private void Subtest_Download_Chunks(int chunkSize, bool sync = true, int cancelRequest = 0,
             string downloadUri = "http://www.sample.com")
         {
-            // reset the steam
-            StreamContent.Position = 0;
-
-            var handler = new MultipleChunksMessageHandler();
+            var handler = new MultipleChunksMessageHandler(MediaContent);
             handler.StatusCode = HttpStatusCode.OK;
             handler.ChunkSize = chunkSize;
             handler.DownloadUri = new Uri(downloadUri +
@@ -207,11 +218,8 @@ namespace Google.Apis.Tests.Apis.Download
             }
             handler.CancellationTokenSource = new CancellationTokenSource();
 
-            int expectedCalls = (int)Math.Ceiling((double)StreamContent.Length / chunkSize);
-            using (var service = new MockClientService(new BaseClientService.Initializer()
-                {
-                    HttpClientFactory = new MockHttpClientFactory(handler)
-                }))
+            int expectedCalls = (int)Math.Ceiling((double) MediaContent.Length / chunkSize);
+            using (var service = CreateMockClientService(handler))
             {
                 var downloader = new MediaDownloader(service);
                 downloader.ChunkSize = chunkSize;
@@ -258,34 +266,31 @@ namespace Google.Apis.Tests.Apis.Download
                     Assert.NotNull(lastProgress);
                     Assert.Null(lastProgress.Exception);
                     Assert.That(lastProgress.Status, Is.EqualTo(DownloadStatus.Completed));
-                    Assert.That(lastProgress.BytesDownloaded, Is.EqualTo(StreamContent.Length));
+                    Assert.That(lastProgress.BytesDownloaded, Is.EqualTo(MediaContent.Length));
 
-                    byte[] read = new byte[1000];
-                    outputStream.Position = 0;
-                    int length = outputStream.Read(read, 0, 1000);
-                    Assert.That(Encoding.UTF8.GetString(read, 0, length), Is.EqualTo(MediaContent));
+                    byte[] actual = outputStream.ToArray();
+                    CollectionAssert.AreEqual(MediaContent, actual);
                 }
             }
         }
 
-        /// <summary>Tests that download reports errors.</summary>
+        /// <summary>Tests that download reports errors, deserializing a JSON response correctly.</summary>
         [Test]
-        public void Download_Error()
+        public void Download_Error_JsonResponse()
         {
-            var downloadUri = "http://www.sample.com?alt=media";
+            var downloadUri = "http://www.sample.com";
             var chunkSize = 100;
-            // reset the steam
-            StreamContent.Position = 0;
+            var error = new RequestError { Code = 12345, Message = "Text", Errors = new[] { new SingleError { Message = "Nested error" } } };
+            var response = new StandardResponse<object> { Error = error };
+            var responseText = new NewtonsoftJsonSerializer().Serialize(response);
 
-            var handler = new MultipleChunksMessageHandler();
+            var handler = new MultipleChunksMessageHandler { ErrorResponse = responseText };
             handler.StatusCode = HttpStatusCode.BadRequest;
             handler.ChunkSize = chunkSize;
-            handler.DownloadUri = new Uri(downloadUri);
+            // The media downloader adds the parameter...
+            handler.DownloadUri = new Uri(downloadUri + "?alt=media");
 
-            using (var service = new MockClientService(new BaseClientService.Initializer()
-                {
-                    HttpClientFactory = new MockHttpClientFactory(handler)
-                }))
+            using (var service = CreateMockClientService(handler))
             {
                 var downloader = new MediaDownloader(service);
                 downloader.ChunkSize = chunkSize;
@@ -300,7 +305,58 @@ namespace Google.Apis.Tests.Apis.Download
 
                 var lastProgress = progressList.LastOrDefault();
                 Assert.That(lastProgress.Status, Is.EqualTo(DownloadStatus.Failed));
+                GoogleApiException exception = (GoogleApiException) lastProgress.Exception;
+                Assert.That(exception.HttpStatusCode, Is.EqualTo(handler.StatusCode));
+                // Just a smattering of checks - if these two pass, it's surely okay.
+                Assert.That(exception.Error.Code, Is.EqualTo(error.Code));
+                Assert.That(exception.Error.Errors[0].Message, Is.EqualTo(error.Errors[0].Message));
             }
+        }
+
+        [Test]
+        public void Download_Error_PlaintextResponse()
+        {
+            var downloadUri = "http://www.sample.com";
+            var chunkSize = 100;
+            var responseText = "Not Found";
+
+            var handler = new MultipleChunksMessageHandler { ErrorResponse = responseText };
+            handler.StatusCode = HttpStatusCode.NotFound;
+            handler.ChunkSize = chunkSize;
+            // The media downloader adds the parameter...
+            handler.DownloadUri = new Uri(downloadUri + "?alt=media");
+
+            using (var service = CreateMockClientService(handler))
+            {
+                var downloader = new MediaDownloader(service);
+                downloader.ChunkSize = chunkSize;
+                IList<IDownloadProgress> progressList = new List<IDownloadProgress>();
+                downloader.ProgressChanged += (p) =>
+                {
+                    progressList.Add(p);
+                };
+
+                var outputStream = new MemoryStream();
+                downloader.Download(downloadUri, outputStream);
+
+                var lastProgress = progressList.LastOrDefault();
+                Assert.That(lastProgress.Status, Is.EqualTo(DownloadStatus.Failed));
+                GoogleApiException exception = (GoogleApiException) lastProgress.Exception;
+                Assert.That(exception.HttpStatusCode, Is.EqualTo(handler.StatusCode));
+                Assert.That(exception.Message, Is.EqualTo(responseText));
+                Assert.IsNull(exception.Error);
+            }
+        }
+
+        /// <summary>
+        /// Creates a mock client service whose HTTP client factory uses the specified message handler.
+        /// </summary>
+        private static IClientService CreateMockClientService(HttpMessageHandler handler)
+        {
+            return new MockClientService(new BaseClientService.Initializer
+            {
+                HttpClientFactory = new MockHttpClientFactory(handler)
+            });
         }
     }
 }

--- a/Src/GoogleApis/Apis/[Media]/Download/MediaDownloader.cs
+++ b/Src/GoogleApis/Apis/[Media]/Download/MediaDownloader.cs
@@ -22,6 +22,7 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using Google.Apis.Logging;
+using Google.Apis.Media;
 using Google.Apis.Requests;
 using Google.Apis.Services;
 using Google.Apis.Util;
@@ -210,12 +211,7 @@ namespace Google.Apis.Download
                     {
                         if (!response.IsSuccessStatusCode)
                         {
-                            var error = await service.DeserializeError(response).ConfigureAwait(false);
-                            throw new GoogleApiException(service.Name, error.ToString())
-                            {
-                                Error = error,
-                                HttpStatusCode = response.StatusCode
-                            };
+                            throw await MediaApiErrorHandling.ExceptionForResponseAsync(service, response).ConfigureAwait(false);
                         }
 
                         // Read the content and copy to the parameter's stream.

--- a/Src/GoogleApis/Apis/[Media]/MediaApiErrorHandling.cs
+++ b/Src/GoogleApis/Apis/[Media]/MediaApiErrorHandling.cs
@@ -1,0 +1,68 @@
+﻿/*
+Copyright 2015 Google Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using System.Net.Http;
+using System.Threading.Tasks;
+
+using Newtonsoft.Json;
+
+using Google.Apis.Requests;
+using Google.Apis.Services;
+using Google.Apis.Util;
+
+namespace Google.Apis.Media
+{
+    /// <summary>
+    /// Common error handling code for the Media API.
+    /// </summary>
+    internal static class MediaApiErrorHandling
+    {
+        /// <summary>
+        /// Creates a suitable exception for an HTTP response, attempting to parse the body as
+        /// JSON but falling back to just using the text as the message.
+        /// </summary>
+        internal static async Task<GoogleApiException> ExceptionForResponseAsync(
+            IClientService service,
+            HttpResponseMessage response)
+        {
+            // If we can't even read the response, let that excpetion bubble up, just as it would have done
+            // if the error had been occurred when sending the request.
+            string responseText = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            RequestError parsedError = null;
+            string message = responseText;
+            try
+            {
+                parsedError = service.Serializer.Deserialize<StandardResponse<object>>(responseText).Error;
+                if (parsedError != null)
+                {
+                    message = parsedError.ToString();
+                }
+            }
+            catch (JsonException)
+            {
+                // Just make do with a null RequestError, and the response text set to the body of the response.
+                // The contents of the caught exception aren't particularly useful - we don't need to include it
+                // as a cause, for example. The expectation is that the exception returned by this method (below)
+                // will be thrown by the caller.
+            }
+            return new GoogleApiException(service.Name, message)
+            {
+                Error = parsedError,
+                HttpStatusCode = response.StatusCode
+            };
+        }
+    }
+}

--- a/Src/GoogleApis/Apis/[Media]/Upload/ResumableUpload.cs
+++ b/Src/GoogleApis/Apis/[Media]/Upload/ResumableUpload.cs
@@ -25,6 +25,7 @@ using System.Threading.Tasks;
 
 using Google.Apis.Http;
 using Google.Apis.Logging;
+using Google.Apis.Media;
 using Google.Apis.Requests;
 using Google.Apis.Services;
 using Google.Apis.Testing;
@@ -548,13 +549,7 @@ namespace Google.Apis.Upload
                 Logger.Debug("MediaUpload[{0}] - {1} Bytes were sent successfully", UploadUri, BytesServerReceived);
                 return false;
             }
-
-            var error = await Service.DeserializeError(response).ConfigureAwait(false);
-            throw new GoogleApiException(Service.Name, error.ToString())
-            {
-                Error = error,
-                HttpStatusCode = response.StatusCode
-            };
+            throw await MediaApiErrorHandling.ExceptionForResponseAsync(Service, response).ConfigureAwait(false);
         }
 
         /// <summary>A callback when the media was uploaded successfully.</summary>

--- a/Src/GoogleApis/GoogleApis.csproj
+++ b/Src/GoogleApis/GoogleApis.csproj
@@ -88,6 +88,7 @@
     <Compile Include="Apis\[Media]\Download\IDownloadProgress.cs" />
     <Compile Include="Apis\[Media]\Download\IMediaDownloader.cs" />
     <Compile Include="Apis\[Media]\Download\MediaDownloader.cs" />
+    <Compile Include="Apis\[Media]\MediaApiErrorHandling.cs" />
     <Compile Include="Apis\[Media]\Upload\IUploadProgress.cs" />
     <Compile Include="Apis\[Media]\Upload\ResumableUpload.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
This addresses issue #645.

(The majority of the change is in the tests, which were somewhat tricky.)

// cc @chrsmith @peleyal 