### PR TITLE
Generate, build, and package API client libraries

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ClientGeneratorHttps"]
+	path = ClientGenerator
+	url = https://github.com/mmdriley/apis-client-generator

--- a/GeneratedLibraries.proj
+++ b/GeneratedLibraries.proj
@@ -1,0 +1,99 @@
+<Project ToolsVersion="12.0" DefaultTargets="Clean;UpdateDiscoveryDocuments;Generate;Build;Package" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!--
+    This project file requires that 'nuget' and 'python' (version 2)
+    be in the user's %PATH%.
+  -->
+
+  <Target Name="Clean">
+    <!-- Remove downloaded or generated artifacts. -->
+    <RemoveDir Directories="DiscoveryJson;Src/Generated;NuPkgs/Generated" />
+  </Target>
+
+  <Target Name="UpdateDiscoveryDocuments">
+    <MakeDir Directories="DiscoveryJson" />
+    <!-- 'python -u' turns off buffering so status is printed line-by-line. -->
+    <Exec Command="python -u get_discovery_documents.py --destination_dir .\DiscoveryJson" />
+  </Target>
+
+  <Target Name="Generate">
+    <PropertyGroup>
+      <_GenerateLibraryTool>ClientGenerator\generate_library.cmd</_GenerateLibraryTool>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <_DiscoveryDocument Include="DiscoveryJson\*.json" />
+    </ItemGroup>
+
+    <MakeDir Directories="Src\Generated" />
+    <Exec Command="&quot;$(_GenerateLibraryTool)&quot; --input=&quot;%(_DiscoveryDocument.FullPath)&quot; --language=csharp --output_dir=Src\Generated" />
+  </Target>
+
+  <PropertyGroup>
+    <Configuration Condition="'$(Configuration)' == ''">ReleaseSigned</Configuration>
+  </PropertyGroup>
+
+  <!-- Warnings to disable -->
+  <PropertyGroup>
+    <!-- XML comment on 'construct' has badly formed XML — 'reason' -->
+    <NoWarn>$(NoWarn);1570</NoWarn>
+
+    <!-- XML comment is not placed on a valid language element -->
+    <NoWarn>$(NoWarn);1587</NoWarn>
+
+    <!-- Missing XML comment for publicly visible type or member 'Type_or_Member' -->
+    <NoWarn>$(NoWarn);1591</NoWarn>
+  </PropertyGroup>
+
+  <!--
+    Create a list of generated projects. This has to be done in a target,
+    rather than at toplevel, because these projects don't exist until
+    the Generate target has run.
+  -->
+  <Target Name="BuildProjectList">
+    <!-- Generated libraries that don't compile -->
+    <ItemGroup>
+      <!-- Last released May 2015 (1.9.0.1030) -->
+      <BrokenProject Include="Src\Generated\Google.Apis.Games.v1\*" />
+
+      <!-- Last released April 2014 (1.8.1.1750) -->
+      <BrokenProject Include="Src\Generated\Google.Apis.IdentityToolkit.v3\*" />
+
+      <!-- Last released Jan 2015 (1.9.0.860) -->
+      <BrokenProject Include="Src\Generated\Google.Apis.Oauth2.v1\*" />
+    </ItemGroup>
+
+    <!-- All generated libraries except the broken ones listed above -->
+    <ItemGroup>
+      <Project Include="Src\Generated\*\*.csproj" Exclude="@(BrokenProject)">
+        <!--
+          TODO(mmdriley): Maybe we should add this metadata in the Build target?
+        -->
+        <AdditionalProperties>
+          Configuration=$(Configuration);
+          NoWarn=$(NoWarn)
+        </AdditionalProperties>
+      </Project>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="Build" DependsOnTargets="BuildProjectList">
+    <!--
+      We only need to restore packages for one API, since they have identical
+      packages.config. The choice of the discovery API is mostly arbitrary;
+      it's an API that's always likely to be there.
+    -->
+    <Exec Command="nuget restore Src\Generated\Google.Apis.Discovery.v1\packages.config -PackagesDirectory Src\Generated\packages" />
+
+    <MSBuild Projects="@(Project)" BuildInParallel="True" Targets="Build" />
+  </Target>
+
+  <Target Name="Package" DependsOnTargets="BuildProjectList">
+    <MakeDir Directories="NuPkgs\Generated" />
+
+    <ItemGroup>
+      <NuSpec Include="Src\Generated\*\*.nuspec" Exclude="@(BrokenProject)" />
+    </ItemGroup>
+
+    <Exec Command="nuget pack &quot;%(NuSpec.FullPath)&quot; -OutputDirectory NuPkgs\Generated" />
+  </Target>
+</Project>

--- a/get_discovery_documents.py
+++ b/get_discovery_documents.py
@@ -1,0 +1,66 @@
+# Copyright 2015 Google Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import json
+from operator import itemgetter
+import os
+import urllib2
+
+
+def GetDiscoveryDocuments(destination_dir):
+  """Download discovery documents for all Google APIs.
+
+  The discovery documents are saved in destination_dir in files named
+  APINAME_VERSION.json (e.g. adexchangebuyer_v1.4.json). Existing files are
+  overwritten. The destination directory is created if it doesn't exist.
+  """
+  discovery_endpoint = 'https://www.googleapis.com/discovery/v1/apis'
+
+  # Make sure the Discovery server never treats us as a Google-internal client.
+  headers = {'X-User-Ip': '0.0.0.0'}
+
+  discovery_request = urllib2.Request(discovery_endpoint, headers=headers)
+  discovery_json = urllib2.urlopen(discovery_request)
+  discovery = json.load(discovery_json)
+
+  if not os.path.exists(destination_dir):
+    os.makedirs(destination_dir)
+
+  for api in sorted(discovery['items'], key=itemgetter('name', 'version')):
+    filename = '{0}_{1}.json'.format(api['name'], api['version'])
+    filename = os.path.join(destination_dir, filename)
+
+    api_url = api['discoveryRestUrl']
+    api_request = urllib2.Request(api_url, headers=headers)
+    api_json = urllib2.urlopen(api_request)
+
+    # Use binary mode to ensure the file is written exactly as received.
+    with open(filename, 'wb') as discovery_file:
+      discovery_file.write(api_json.read())
+
+    print(filename)
+
+
+if __name__ == '__main__':
+  args_parser = argparse.ArgumentParser(
+      description='Download discovery documents for Google APIs')
+  args_parser.add_argument(
+    '--destination_dir',
+    metavar='DIR',
+    default=os.path.join('.', 'DiscoveryJson'),
+    help=('Directory to which to write discovery documents\n'
+          '(default: .\DiscoveryJson)'))
+  args = args_parser.parse_args()
+  GetDiscoveryDocuments(args.destination_dir)


### PR DESCRIPTION
This change brings in a copy of the google/apis-client-generator code used to generate per-API libraries, and wires it up with MSBuild.

The process is orchestrated by GeneratedLibraries.proj.

First, we download the discovery documents. This is isolated as its own step so we have copies of the actual discovery documents used to produce the generated libraries. This leaves the rest of the build hermetic and will help us reproduce and fix codegen problems in the future.

Next, the client generator is run on each discovery document. The generated source ends up at Src/Generated/<API PACKAGE NAME>.

Each client library project is built. The GeneratedLibraries.proj includes a list of the projects that don't currently build so they can be ignored for now.

Finally, we run NuGet to package each of the libraries. The packages are put into NuPkgs/Generated.