### PR TITLE
Add an example of constructing a PageStreamer.

### DIFF
--- a/Src/Support/GoogleApis/Apis/Requests/PageStreamer.cs
+++ b/Src/Support/GoogleApis/Apis/Requests/PageStreamer.cs
@@ -21,7 +21,7 @@ using System.Threading.Tasks;
 
 namespace Google.Apis.Requests
 {
-    // TODO(jskeet and LindaLawton): Add an example in the doc comment.
+    // TODO(jskeet): Make sure one of our samples uses this.
 
     /// <summary>
     /// A page streamer is a helper to provide both synchronous and asynchronous page streaming
@@ -33,6 +33,22 @@ namespace Google.Apis.Requests
     /// and then use the instance methods to obtain paginated results.
     /// </para>
     /// </remarks>
+    /// <example>
+    /// To construct a page streamer to return snippets from the YouTube v3 Data API, you might use code
+    /// such as the following. The pattern for other APIs would be very similar, with the <c>request.PageToken</c>,
+    /// <c>response.NextPageToken</c> and <c>response.Items</c> properties potentially having different names. Constructing
+    /// the page streamer doesn't require any service references or authentication, so it's completely safe to perform this
+    /// in a type initializer.
+    /// <code><![CDATA[
+    /// using Google.Apis.YouTube.v3;
+    /// using Google.Apis.YouTube.v3.Data;
+    /// ...
+    /// private static readonly snippetPageStreamer = new PageStreamer<SearchResult, SearchResource.ListRequest, SearchListResponse, string>(
+    ///     (request, token) => request.PageToken = token,
+    ///     response => response.NextPageToken,
+    ///     response => response.Items);
+    /// ]]></code>
+    /// </example>
     /// <typeparam name="TResource">The type of resource being paginated</typeparam>
     /// <typeparam name="TRequest">The type of request used to fetch pages</typeparam>
     /// <typeparam name="TResponse">The type of response obtained when fetching pages</typeparam>


### PR DESCRIPTION
More options:

- Put this documentation into the constructor call instead
- Put this documentation into the constructor call as well
- Make this a full console app example (with a placeholder for the API key)
- Move this to documentation to https://developers.google.com/api-client-library/dotnet/get_started (maybe a new "how to"?)

Easiest to discuss the options with something concrete :)

This would complete the code part of #632.

// cc @LindaLawton @peleyal 