### PR TITLE
Custom Auth Query Params (2)

### DIFF
--- a/Src/Support/GoogleApis.Auth.Tests/GoogleApis.Auth.Tests.csproj
+++ b/Src/Support/GoogleApis.Auth.Tests/GoogleApis.Auth.Tests.csproj
@@ -100,6 +100,7 @@
     <Compile Include="OAuth2\ComputeCredentialTests.cs" />
     <Compile Include="OAuth2\Flows\AuthorizationCodeFlowTests.cs" />
     <Compile Include="OAuth2\BearerTokenTests.cs" />
+    <Compile Include="OAuth2\Flows\GoogleAuthorizationCodeFlowTests.cs" />
     <Compile Include="OAuth2\Requests\AuthorizationCodeRequestUrlTests.cs" />
     <Compile Include="OAuth2\Requests\AuthorizationCodeTokenRequestTests.cs" />
     <Compile Include="OAuth2\Requests\GoogleAuthorizationCodeRequestUrlTest.cs" />

--- a/Src/Support/GoogleApis.Auth.Tests/OAuth2/Flows/GoogleAuthorizationCodeFlowTests.cs
+++ b/Src/Support/GoogleApis.Auth.Tests/OAuth2/Flows/GoogleAuthorizationCodeFlowTests.cs
@@ -53,8 +53,7 @@ namespace Google.Apis.Auth.OAuth2.Flows
                 RevokeTokenUrl = revokeTokenUrl,
                 IncludeGrantedScopes = includeGrantedScopes,
                 UserDefinedQueryParams = userDefinedParams,
-                //HttpClientFactory //set this up 
-                ClientSecrets = new ClientSecrets() //to avoid throwing error
+                ClientSecrets = new ClientSecrets()
             };
         }
 
@@ -84,27 +83,7 @@ namespace Google.Apis.Auth.OAuth2.Flows
         [Test]
         public void RevokeTokenAsyncTest()
         {
-            var mockDataStore = new Mock<IDataStore>();
-            mockDataStore.Setup(ds => ds.DeleteAsync<TokenResponse>("user")).
-                Returns(new TaskCompletionSource<TokenResponse>().Task);
-
-            var mockHttpClient = new Mock<ConfigurableHttpClient>();
-            mockHttpClient.Setup(mhc => mhc.SendAsync(
-                It.IsAny<HttpRequestMessage>(), 
-                It.IsAny<CancellationToken>()
-                )).Returns(TaskEx.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK)));
-
-            var mockHttpClientFactory = new Mock<IHttpClientFactory>();
-            mockHttpClientFactory.Setup(mhcf => mhcf.CreateHttpClient(
-                It.IsAny<CreateHttpClientArgs>()
-                )).Returns(mockHttpClient.Object);
-
-            initializer.HttpClientFactory = mockHttpClientFactory.Object;
-
-            var flow = new GoogleAuthorizationCodeFlow(initializer);
-
-            var result = flow.RevokeTokenAsync("user","token", new CancellationToken(false));
-            mockDataStore.Verify(ds => ds.DeleteAsync<TokenResponse>("user"));
+            //TODO
         }
     }
 }

--- a/Src/Support/GoogleApis.Auth.Tests/OAuth2/Flows/GoogleAuthorizationCodeFlowTests.cs
+++ b/Src/Support/GoogleApis.Auth.Tests/OAuth2/Flows/GoogleAuthorizationCodeFlowTests.cs
@@ -80,10 +80,6 @@ namespace Google.Apis.Auth.OAuth2.Flows
             Assert.AreEqual(request.RedirectUri, "TestRedirectUri");
         }
 
-        [Test]
-        public void RevokeTokenAsyncTest()
-        {
-            //TODO
-        }
+        //TODO(squid808): Add tests for RevokeToken.
     }
 }

--- a/Src/Support/GoogleApis.Auth.Tests/OAuth2/Flows/GoogleAuthorizationCodeFlowTests.cs
+++ b/Src/Support/GoogleApis.Auth.Tests/OAuth2/Flows/GoogleAuthorizationCodeFlowTests.cs
@@ -1,0 +1,110 @@
+﻿/*
+Copyright 2016 Google Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Moq;
+using NUnit.Framework;
+
+using Google.Apis.Auth.OAuth2.Flows;
+using Google.Apis.Auth.OAuth2.Requests;
+using Google.Apis.Auth.OAuth2.Responses;
+using Google.Apis.Http;
+using Google.Apis.Util.Store;
+
+namespace Google.Apis.Auth.OAuth2.Flows
+{
+    /// <summary>Tests for <see cref="Google.Apis.Auth.OAuth2.Flows.GoogleAuthorizationCodeFlow"/>.</summary>
+    public class GoogleAuthorizationCodeFlowTests
+    {
+        GoogleAuthorizationCodeFlow.Initializer initializer { get; set; }
+        List<KeyValuePair<string, string>> userDefinedParams { get; set; }
+
+        [SetUp]
+        public void GoogleAuthorizationCodeFlowTestSetup()
+        {
+            string revokeTokenUrl = "Revoke Token Url";
+            bool? includeGrantedScopes = true;
+            userDefinedParams = new List<KeyValuePair<string, string>>
+            {
+                new KeyValuePair<string,string>("customParam1","customVal1"),
+                new KeyValuePair<string,string>("customParam2","customVal2")
+            };
+
+            initializer = new GoogleAuthorizationCodeFlow.Initializer()
+            {
+                RevokeTokenUrl = revokeTokenUrl,
+                IncludeGrantedScopes = includeGrantedScopes,
+                UserDefinedQueryParams = userDefinedParams,
+                //HttpClientFactory //set this up 
+                ClientSecrets = new ClientSecrets() //to avoid throwing error
+            };
+        }
+
+        [Test]
+        public void ConstructorTest()
+        {
+            var flow = new GoogleAuthorizationCodeFlow(initializer);
+
+            Assert.That(flow.RevokeTokenUrl, Is.EqualTo(initializer.RevokeTokenUrl));
+            Assert.That(flow.IncludeGrantedScopes, Is.EqualTo(initializer.IncludeGrantedScopes));
+            Assert.That(flow.UserDefinedQueryParams, Is.EqualTo(initializer.UserDefinedQueryParams));
+        }
+        
+        [Test]
+        public void CreateAuthorizationCodeRequestTest()
+        {
+            var flow = new GoogleAuthorizationCodeFlow(initializer);
+
+            var request = flow.CreateAuthorizationCodeRequest("TestRedirectUri") as GoogleAuthorizationCodeRequestUrl;
+
+            Assert.AreEqual(request.AccessType, "offline");
+            Assert.AreEqual(request.IncludeGrantedScopes, "true");
+            Assert.AreEqual(request.UserDefinedQueryParams, userDefinedParams);
+            Assert.AreEqual(request.RedirectUri, "TestRedirectUri");
+        }
+
+        [Test]
+        public void RevokeTokenAsyncTest()
+        {
+            var mockDataStore = new Mock<IDataStore>();
+            mockDataStore.Setup(ds => ds.DeleteAsync<TokenResponse>("user")).
+                Returns(new TaskCompletionSource<TokenResponse>().Task);
+
+            var mockHttpClient = new Mock<ConfigurableHttpClient>();
+            mockHttpClient.Setup(mhc => mhc.SendAsync(
+                It.IsAny<HttpRequestMessage>(), 
+                It.IsAny<CancellationToken>()
+                )).Returns(TaskEx.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK)));
+
+            var mockHttpClientFactory = new Mock<IHttpClientFactory>();
+            mockHttpClientFactory.Setup(mhcf => mhcf.CreateHttpClient(
+                It.IsAny<CreateHttpClientArgs>()
+                )).Returns(mockHttpClient.Object);
+
+            initializer.HttpClientFactory = mockHttpClientFactory.Object;
+
+            var flow = new GoogleAuthorizationCodeFlow(initializer);
+
+            var result = flow.RevokeTokenAsync("user","token", new CancellationToken(false));
+            mockDataStore.Verify(ds => ds.DeleteAsync<TokenResponse>("user"));
+        }
+    }
+}

--- a/Src/Support/GoogleApis.Auth/OAuth2/Flows/GoogleAuthorizationCodeFlow.cs
+++ b/Src/Support/GoogleApis.Auth/OAuth2/Flows/GoogleAuthorizationCodeFlow.cs
@@ -102,7 +102,9 @@ namespace Google.Apis.Auth.OAuth2.Flows
             /// <summary>Gets or sets the token revocation URL.</summary>
             public string RevokeTokenUrl { get; set; }
 
-            /// <summary>Gets or sets the optional indicator for including granted scopes for incremental authorization.</summary>
+            /// <summary>
+            /// Gets or sets the optional indicator for including granted scopes for incremental authorization.
+            /// </summary>
             public bool? IncludeGrantedScopes { get; set; }
 
             /// <summary>Gets or sets the optional user defined query parameters.</summary>

--- a/Src/Support/GoogleApis.Auth/OAuth2/Flows/GoogleAuthorizationCodeFlow.cs
+++ b/Src/Support/GoogleApis.Auth/OAuth2/Flows/GoogleAuthorizationCodeFlow.cs
@@ -55,6 +55,7 @@ namespace Google.Apis.Auth.OAuth2.Flows
         {
             revokeTokenUrl = initializer.RevokeTokenUrl;
             includeGrantedScopes = initializer.IncludeGrantedScopes;
+            userDefinedQueryParams = initializer.UserDefinedQueryParams;
         }
 
         public override AuthorizationCodeRequestUrl CreateAuthorizationCodeRequest(string redirectUri)

--- a/Src/Support/GoogleApis.Auth/OAuth2/Flows/GoogleAuthorizationCodeFlow.cs
+++ b/Src/Support/GoogleApis.Auth/OAuth2/Flows/GoogleAuthorizationCodeFlow.cs
@@ -45,7 +45,9 @@ namespace Google.Apis.Auth.OAuth2.Flows
 
         /// <summary>Gets the user defined query parameters.</summary>
         public IEnumerable<KeyValuePair<string, string>> UserDefinedQueryParams
-        { get { return userDefinedQueryParams; } }
+        { 
+            get { return userDefinedQueryParams; } 
+        }
 
         /// <summary>Constructs a new Google authorization code flow.</summary>
         public GoogleAuthorizationCodeFlow(Initializer initializer)

--- a/Src/Support/GoogleApis.Auth/OAuth2/Flows/GoogleAuthorizationCodeFlow.cs
+++ b/Src/Support/GoogleApis.Auth/OAuth2/Flows/GoogleAuthorizationCodeFlow.cs
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -40,6 +41,12 @@ namespace Google.Apis.Auth.OAuth2.Flows
         /// <summary>Gets or sets the include granted scopes indicator.</summary>
         public bool? IncludeGrantedScopes { get { return includeGrantedScopes; } }
 
+        private readonly IEnumerable<KeyValuePair<string, string>> userDefinedQueryParams;
+
+        /// <summary>Gets the user defined query parameters.</summary>
+        public IEnumerable<KeyValuePair<string, string>> UserDefinedQueryParams
+        { get { return userDefinedQueryParams; } }
+
         /// <summary>Constructs a new Google authorization code flow.</summary>
         public GoogleAuthorizationCodeFlow(Initializer initializer)
             : base(initializer)
@@ -56,7 +63,8 @@ namespace Google.Apis.Auth.OAuth2.Flows
                 Scope = string.Join(" ", Scopes),
                 RedirectUri = redirectUri,
                 IncludeGrantedScopes = IncludeGrantedScopes.HasValue
-                    ? IncludeGrantedScopes.Value.ToString().ToLower() : null
+                    ? IncludeGrantedScopes.Value.ToString().ToLower() : null,
+                UserDefinedQueryParams = UserDefinedQueryParams
             };
         }
 
@@ -93,6 +101,9 @@ namespace Google.Apis.Auth.OAuth2.Flows
 
             /// <summary>Gets or sets the optional indicator for including granted scopes for incremental authorization.</summary>
             public bool? IncludeGrantedScopes { get; set; }
+
+            /// <summary>Gets or sets the optional user defined query parameters.</summary>
+            public IEnumerable<KeyValuePair<string, string>> UserDefinedQueryParams { get; set; }
 
             /// <summary>
             /// Constructs a new initializer. Sets Authorization server URL to 

--- a/Src/Support/GoogleApis.Auth/OAuth2/Requests/GoogleAuthorizationCodeRequestUrl.cs
+++ b/Src/Support/GoogleApis.Auth/OAuth2/Requests/GoogleAuthorizationCodeRequestUrl.cs
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 using System;
+using System.Collections.Generic;
 
 namespace Google.Apis.Auth.OAuth2.Requests
 {
@@ -58,6 +59,14 @@ namespace Google.Apis.Auth.OAuth2.Requests
         [Google.Apis.Util.RequestParameterAttribute("include_granted_scopes",
             Google.Apis.Util.RequestParameterType.Query)]
         public string IncludeGrantedScopes { get; set; }
+
+        /// <summary>
+        /// Gets or sets a collection of user defined query parameters to facilitate any not explicitly supported
+        /// by the library which will be included in the resultant authentication URL.
+        /// </summary>
+        [Google.Apis.Util.RequestParameterAttribute("user_defined_query_parameters",
+            Google.Apis.Util.RequestParameterType.UserDefiniedQueries)]
+        public IEnumerable<KeyValuePair<string, string>> UserDefinedQueryParams { get; set; }
 
         /// <summary>
         /// Constructs a new authorization code request with the given authorization server URL. This constructor sets

--- a/Src/Support/GoogleApis.Auth/OAuth2/Requests/GoogleAuthorizationCodeRequestUrl.cs
+++ b/Src/Support/GoogleApis.Auth/OAuth2/Requests/GoogleAuthorizationCodeRequestUrl.cs
@@ -64,8 +64,7 @@ namespace Google.Apis.Auth.OAuth2.Requests
         /// Gets or sets a collection of user defined query parameters to facilitate any not explicitly supported
         /// by the library which will be included in the resultant authentication URL.
         /// </summary>
-        [Google.Apis.Util.RequestParameterAttribute("user_defined_query_parameters",
-            Google.Apis.Util.RequestParameterType.UserDefiniedQueries)]
+        [Google.Apis.Util.RequestParameterAttribute(Google.Apis.Util.RequestParameterType.UserDefinedQueries)]
         public IEnumerable<KeyValuePair<string, string>> UserDefinedQueryParams { get; set; }
 
         /// <summary>

--- a/Src/Support/GoogleApis.Auth/OAuth2/Requests/GoogleAuthorizationCodeRequestUrl.cs
+++ b/Src/Support/GoogleApis.Auth/OAuth2/Requests/GoogleAuthorizationCodeRequestUrl.cs
@@ -65,7 +65,8 @@ namespace Google.Apis.Auth.OAuth2.Requests
         /// by the library which will be included in the resultant authentication URL.
         /// </summary>
         /// <remarks>
-        /// The name of this parameter is used only for the constructor and will not end up in the resultant query string.
+        /// The name of this parameter is used only for the constructor and will not end up in the resultant query
+        /// string.
         /// </remarks>
         [Google.Apis.Util.RequestParameterAttribute("user_defined_query_params",
             Google.Apis.Util.RequestParameterType.UserDefinedQueries)]

--- a/Src/Support/GoogleApis.Auth/OAuth2/Requests/GoogleAuthorizationCodeRequestUrl.cs
+++ b/Src/Support/GoogleApis.Auth/OAuth2/Requests/GoogleAuthorizationCodeRequestUrl.cs
@@ -64,7 +64,11 @@ namespace Google.Apis.Auth.OAuth2.Requests
         /// Gets or sets a collection of user defined query parameters to facilitate any not explicitly supported
         /// by the library which will be included in the resultant authentication URL.
         /// </summary>
-        [Google.Apis.Util.RequestParameterAttribute(Google.Apis.Util.RequestParameterType.UserDefinedQueries)]
+        /// <remarks>
+        /// The name of this parameter is used only for the constructor and will not end up in the resultant query string.
+        /// </remarks>
+        [Google.Apis.Util.RequestParameterAttribute("user_defined_query_params",
+            Google.Apis.Util.RequestParameterType.UserDefinedQueries)]
         public IEnumerable<KeyValuePair<string, string>> UserDefinedQueryParams { get; set; }
 
         /// <summary>

--- a/Src/Support/GoogleApis.Core/Apis/Requests/Parameters/ParameterUtils.cs
+++ b/Src/Support/GoogleApis.Core/Apis/Requests/Parameters/ParameterUtils.cs
@@ -126,7 +126,7 @@ namespace Google.Apis.Requests.Parameters
                 {
                     if (attribute.Type == RequestParameterType.UserDefinedQueries)
                     {
-                        if (value.GetType() == typeof(IEnumerable<KeyValuePair<string, string>>))
+                        if (typeof(IEnumerable<KeyValuePair<string, string>>).IsAssignableFrom(value.GetType()))
                         {
                             foreach (var pair in (IEnumerable<KeyValuePair<string, string>>)value)
                             {

--- a/Src/Support/GoogleApis.Core/Apis/Requests/Parameters/ParameterUtils.cs
+++ b/Src/Support/GoogleApis.Core/Apis/Requests/Parameters/ParameterUtils.cs
@@ -30,8 +30,7 @@ namespace Google.Apis.Requests.Parameters
     /// </summary>
     public static class ParameterUtils
     {
-        //TODO: Find out how to resolve the issue with setting up the Logger:
-        private static readonly ILogger Logger = ApplicationContext.Logger.ForType<ParameterUtils>();
+        private static readonly ILogger Logger = ApplicationContext.Logger.ForType(typeof(ParameterUtils));
 
         /// <summary>
         /// Creates a <see cref="System.Net.Http.FormUrlEncodedContent"/> with all the specified parameters in 
@@ -125,7 +124,7 @@ namespace Google.Apis.Requests.Parameters
                 // Call action with the type name and value.
                 if (propertyType.IsValueType || value != null)
                 {
-                    if (attribute.Type == RequestParameterType.UserDefiniedQueries)
+                    if (attribute.Type == RequestParameterType.UserDefinedQueries)
                     {
                         if (value.GetType() == typeof(IEnumerable<KeyValuePair<string, string>>))
                         {
@@ -135,8 +134,9 @@ namespace Google.Apis.Requests.Parameters
                             }
                         }
                         else
-                        {   
-                            //Do logging here
+                        {
+                            Logger.Warning("Parameter marked with RequestParameterType.UserDefinedQueries attribute " +
+                                "was not of type IEnumerable<KeyValuePair<string, string>> and will be skipped.");
                         }
                     }
                     else

--- a/Src/Support/GoogleApis.Core/Apis/Requests/Parameters/ParameterUtils.cs
+++ b/Src/Support/GoogleApis.Core/Apis/Requests/Parameters/ParameterUtils.cs
@@ -20,6 +20,7 @@ using System.Net.Http;
 using System.Linq;
 using System.Reflection;
 
+using Google.Apis.Logging;
 using Google.Apis.Util;
 
 namespace Google.Apis.Requests.Parameters
@@ -29,6 +30,9 @@ namespace Google.Apis.Requests.Parameters
     /// </summary>
     public static class ParameterUtils
     {
+        //TODO: Find out how to resolve the issue with setting up the Logger:
+        private static readonly ILogger Logger = ApplicationContext.Logger.ForType<ParameterUtils>();
+
         /// <summary>
         /// Creates a <see cref="System.Net.Http.FormUrlEncodedContent"/> with all the specified parameters in 
         /// the input request. It uses reflection to iterate over all properties with
@@ -121,7 +125,24 @@ namespace Google.Apis.Requests.Parameters
                 // Call action with the type name and value.
                 if (propertyType.IsValueType || value != null)
                 {
-                    action(attribute.Type, name, value);
+                    if (attribute.Type == RequestParameterType.UserDefiniedQueries)
+                    {
+                        if (value.GetType() == typeof(IEnumerable<KeyValuePair<string, string>>))
+                        {
+                            foreach (var pair in (IEnumerable<KeyValuePair<string, string>>)value)
+                            {
+                                action(RequestParameterType.Query, pair.Key, pair.Value);
+                            }
+                        }
+                        else
+                        {   
+                            //Do logging here
+                        }
+                    }
+                    else
+                    {
+                        action(attribute.Type, name, value);
+                    }
                 }
             }
         }

--- a/Src/Support/GoogleApis.Core/Apis/Requests/Parameters/ParameterUtils.cs
+++ b/Src/Support/GoogleApis.Core/Apis/Requests/Parameters/ParameterUtils.cs
@@ -114,7 +114,7 @@ namespace Google.Apis.Requests.Parameters
                     continue;
                 }
 
-                // Get the name of this parameter from the attribute, if it doesn't exist take a lower-case variant of 
+                // Get the name of this parameter from the attribute, if it doesn't exist take a lower-case variant of
                 // property name.
                 string name = attribute.Name ?? property.Name.ToLower();
 

--- a/Src/Support/GoogleApis.Core/Apis/Util/RequestParameterAttribute.cs
+++ b/Src/Support/GoogleApis.Core/Apis/Util/RequestParameterAttribute.cs
@@ -71,6 +71,9 @@ namespace Google.Apis.Util
         Path,
 
         /// <summary>A query parameter which is inserted into the query portion of the request URI.</summary>
-        Query
+        Query,
+
+        /// <summary>A group of user-defined parameters that will be added in to the query portion of the request URI.</summary>
+        UserDefiniedQueries
     }
 }

--- a/Src/Support/GoogleApis.Core/Apis/Util/RequestParameterAttribute.cs
+++ b/Src/Support/GoogleApis.Core/Apis/Util/RequestParameterAttribute.cs
@@ -51,13 +51,6 @@ namespace Google.Apis.Util
         }
 
         /// <summary>Constructs a new property attribute to be a part of a REST URI.</summary>
-        /// <param name="type">The type of the parameter, either Path, Query or UserDefinedQueries.</param>
-        public RequestParameterAttribute(RequestParameterType type)
-        {
-            this.type = type;
-        }
-
-        /// <summary>Constructs a new property attribute to be a part of a REST URI.</summary>
         /// <param name="name">
         /// The name of the parameter. If the parameter is a path parameter this name will be used to substitute the 
         /// string value into the path, replacing {name}. If the parameter is a query parameter, this parameter will be

--- a/Src/Support/GoogleApis.Core/Apis/Util/RequestParameterAttribute.cs
+++ b/Src/Support/GoogleApis.Core/Apis/Util/RequestParameterAttribute.cs
@@ -51,6 +51,13 @@ namespace Google.Apis.Util
         }
 
         /// <summary>Constructs a new property attribute to be a part of a REST URI.</summary>
+        /// <param name="type">The type of the parameter, either Path or Query.</param>
+        public RequestParameterAttribute(RequestParameterType type)
+        {
+            this.type = type;
+        }
+
+        /// <summary>Constructs a new property attribute to be a part of a REST URI.</summary>
         /// <param name="name">
         /// The name of the parameter. If the parameter is a path parameter this name will be used to substitute the 
         /// string value into the path, replacing {name}. If the parameter is a query parameter, this parameter will be
@@ -74,6 +81,6 @@ namespace Google.Apis.Util
         Query,
 
         /// <summary>A group of user-defined parameters that will be added in to the query portion of the request URI.</summary>
-        UserDefiniedQueries
+        UserDefinedQueries
     }
 }

--- a/Src/Support/GoogleApis.Core/Apis/Util/RequestParameterAttribute.cs
+++ b/Src/Support/GoogleApis.Core/Apis/Util/RequestParameterAttribute.cs
@@ -51,7 +51,7 @@ namespace Google.Apis.Util
         }
 
         /// <summary>Constructs a new property attribute to be a part of a REST URI.</summary>
-        /// <param name="type">The type of the parameter, either Path or Query.</param>
+        /// <param name="type">The type of the parameter, either Path, Query or UserDefinedQueries.</param>
         public RequestParameterAttribute(RequestParameterType type)
         {
             this.type = type;
@@ -63,7 +63,7 @@ namespace Google.Apis.Util
         /// string value into the path, replacing {name}. If the parameter is a query parameter, this parameter will be
         /// added to the query string, in the format "name=value".
         /// </param>
-        /// <param name="type">The type of the parameter, either Path or Query.</param>
+        /// <param name="type">The type of the parameter, either Path, Query or UserDefinedQueries.</param>
         public RequestParameterAttribute(string name, RequestParameterType type)
         {
             this.name = name;
@@ -71,7 +71,7 @@ namespace Google.Apis.Util
         }
     }
 
-    /// <summary>Describe the type of this parameter (Path or Query).</summary>
+    /// <summary>Describe the type of this parameter (Path, Query or UserDefinedQueries).</summary>
     public enum RequestParameterType
     {
         /// <summary>A path parameter which is inserted into the path portion of the request URI.</summary>

--- a/Src/Support/GoogleApis.Core/Apis/Util/RequestParameterAttribute.cs
+++ b/Src/Support/GoogleApis.Core/Apis/Util/RequestParameterAttribute.cs
@@ -73,7 +73,10 @@ namespace Google.Apis.Util
         /// <summary>A query parameter which is inserted into the query portion of the request URI.</summary>
         Query,
 
-        /// <summary>A group of user-defined parameters that will be added in to the query portion of the request URI.</summary>
+        /// <summary>
+        /// A group of user-defined parameters that will be added in to the query portion of the request URI. If this
+        /// type is being used, the name of the RequestParameterAttirbute is meaningless.
+        /// </summary>
         UserDefinedQueries
     }
 }

--- a/Src/Support/GoogleApis.Tests/Apis/Requests/Parameters/ParameterUtilsTest.cs
+++ b/Src/Support/GoogleApis.Tests/Apis/Requests/Parameters/ParameterUtilsTest.cs
@@ -24,6 +24,7 @@ using Google.Apis.Requests.Parameters;
 
 namespace Google.Apis.Tests.Apis.Requests
 {
+    /// <summary>Tests for <see cref="Google.Apis.Requests.Parameters.ParameterUtils"/>.</summary>
     [TestFixture]
     public class ParameterUtilsTest
     {
@@ -32,7 +33,7 @@ namespace Google.Apis.Tests.Apis.Requests
             [Google.Apis.Util.RequestParameterAttribute("first_query_param", Google.Apis.Util.RequestParameterType.Query)]
             public string FirstParam { get; set; }
 
-            [Google.Apis.Util.RequestParameterAttribute("second_query_param", Google.Apis.Util.RequestParameterType.Query)]
+            [Google.Apis.Util.RequestParameterAttribute(Google.Apis.Util.RequestParameterType.Query)]
             public string SecondParam { get; set; }
 
             [Google.Apis.Util.RequestParameterAttribute(Google.Apis.Util.RequestParameterType.UserDefinedQueries)]
@@ -64,8 +65,13 @@ namespace Google.Apis.Tests.Apis.Requests
 
             var result = request.Build().AbsoluteUri;
 
+            //parameter was given a name and a value, so both appear in the uri
             Assert.That(result, Contains.Substring("first_query_param=firstOne"));
-            Assert.That(result, Contains.Substring("second_query_param=secondOne"));
+            
+            //parameter was given value only, so the name is the name of the property in lower case
+            Assert.That(result, Contains.Substring("secondparam=secondOne"));
+
+            //custom parameters are key value pairs representing parameter names and values respectively
             Assert.That(result, Contains.Substring("customParam1=customVal1"));
             Assert.That(result, Contains.Substring("customParam2=customVal2"));
         }

--- a/Src/Support/GoogleApis.Tests/Apis/Requests/Parameters/ParameterUtilsTest.cs
+++ b/Src/Support/GoogleApis.Tests/Apis/Requests/Parameters/ParameterUtilsTest.cs
@@ -36,7 +36,7 @@ namespace Google.Apis.Tests.Apis.Requests
             public string SecondParam { get; set; }
 
             [Google.Apis.Util.RequestParameterAttribute(Google.Apis.Util.RequestParameterType.UserDefinedQueries)]
-            public System.Collections.Generic.KeyValuePair<string, string>[] ParamsCollecetion { get; set; }
+            public List<KeyValuePair<string, string>> ParamsCollection { get; set; }
 
             public System.Uri Build()
             {
@@ -56,7 +56,7 @@ namespace Google.Apis.Tests.Apis.Requests
             {
                 FirstParam = "firstOne",
                 SecondParam = "secondOne",
-                ParamsCollecetion = new KeyValuePair<string, string>[]{
+                ParamsCollection = new List<KeyValuePair<string, string>>{
                     new KeyValuePair<string,string>("customParam1","customVal1"),
                     new KeyValuePair<string,string>("customParam2","customVal2")
                 }

--- a/Src/Support/GoogleApis.Tests/Apis/Requests/Parameters/ParameterUtilsTest.cs
+++ b/Src/Support/GoogleApis.Tests/Apis/Requests/Parameters/ParameterUtilsTest.cs
@@ -33,10 +33,10 @@ namespace Google.Apis.Tests.Apis.Requests
             [Google.Apis.Util.RequestParameterAttribute("first_query_param", Google.Apis.Util.RequestParameterType.Query)]
             public string FirstParam { get; set; }
 
-            [Google.Apis.Util.RequestParameterAttribute(Google.Apis.Util.RequestParameterType.Query)]
+            [Google.Apis.Util.RequestParameterAttribute("second_query_param", Google.Apis.Util.RequestParameterType.Query)]
             public string SecondParam { get; set; }
 
-            [Google.Apis.Util.RequestParameterAttribute(Google.Apis.Util.RequestParameterType.UserDefinedQueries)]
+            [Google.Apis.Util.RequestParameterAttribute("query_param_attribute_name", Google.Apis.Util.RequestParameterType.UserDefinedQueries)]
             public List<KeyValuePair<string, string>> ParamsCollection { get; set; }
 
             public System.Uri Build()
@@ -69,11 +69,14 @@ namespace Google.Apis.Tests.Apis.Requests
             Assert.That(result, Contains.Substring("first_query_param=firstOne"));
             
             //parameter was given value only, so the name is the name of the property in lower case
-            Assert.That(result, Contains.Substring("secondparam=secondOne"));
+            Assert.That(result, Contains.Substring("second_query_param=secondOne"));
 
             //custom parameters are key value pairs representing parameter names and values respectively
             Assert.That(result, Contains.Substring("customParam1=customVal1"));
             Assert.That(result, Contains.Substring("customParam2=customVal2"));
+
+            //assert that the parameter name for the custom parameters does not carry through to the result
+            Assert.IsFalse(result.Contains("query_param_attribute_name"));
         }
     }
 }

--- a/Src/Support/GoogleApis.Tests/Apis/Requests/Parameters/ParameterUtilsTest.cs
+++ b/Src/Support/GoogleApis.Tests/Apis/Requests/Parameters/ParameterUtilsTest.cs
@@ -1,0 +1,74 @@
+﻿/*
+Copyright 2016 Google Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using System.Collections.Generic;
+
+using NUnit.Framework;
+
+using Google.Apis.Util;
+using Google.Apis.Requests;
+using Google.Apis.Requests.Parameters;
+
+namespace Google.Apis.Tests.Apis.Requests
+{
+    [TestFixture]
+    public class ParameterUtilsTest
+    {
+        private class TestRequestUrl
+        {
+            [Google.Apis.Util.RequestParameterAttribute("first_query_param", Google.Apis.Util.RequestParameterType.Query)]
+            public string FirstParam { get; set; }
+
+            [Google.Apis.Util.RequestParameterAttribute("second_query_param", Google.Apis.Util.RequestParameterType.Query)]
+            public string SecondParam { get; set; }
+
+            [Google.Apis.Util.RequestParameterAttribute("user_defined_query_parameters",
+                Google.Apis.Util.RequestParameterType.UserDefiniedQueries)]
+            public System.Collections.Generic.KeyValuePair<string, string>[] ParamsCollecetion { get; set; }
+
+            public System.Uri Build()
+            {
+                var builder = new RequestBuilder()
+                {
+                    BaseUri = new System.Uri("//revokeTokenUrl")
+                };
+                ParameterUtils.InitParameters(builder, this);
+                return builder.BuildUri();
+            }
+        }
+
+        [Test]
+        public void IterateParametersTest()
+        {
+            var request = new TestRequestUrl()
+            {
+                FirstParam = "firstOne",
+                SecondParam = "secondOne",
+                ParamsCollecetion = new KeyValuePair<string, string>[]{
+                    new KeyValuePair<string,string>("customParam1","customVal1"),
+                    new KeyValuePair<string,string>("customParam2","customVal2")
+                }
+            };
+
+            var result = request.Build().AbsoluteUri;
+
+            Assert.That(result, Contains.Substring("first_query_param=firstOne"));
+            Assert.That(result, Contains.Substring("second_query_param=secondOne"));
+            Assert.That(result, Contains.Substring("customParam1=customVal1"));
+            Assert.That(result, Contains.Substring("customParam2=customVal2"));
+        }
+    }
+}

--- a/Src/Support/GoogleApis.Tests/Apis/Requests/Parameters/ParameterUtilsTest.cs
+++ b/Src/Support/GoogleApis.Tests/Apis/Requests/Parameters/ParameterUtilsTest.cs
@@ -35,8 +35,7 @@ namespace Google.Apis.Tests.Apis.Requests
             [Google.Apis.Util.RequestParameterAttribute("second_query_param", Google.Apis.Util.RequestParameterType.Query)]
             public string SecondParam { get; set; }
 
-            [Google.Apis.Util.RequestParameterAttribute("user_defined_query_parameters",
-                Google.Apis.Util.RequestParameterType.UserDefiniedQueries)]
+            [Google.Apis.Util.RequestParameterAttribute(Google.Apis.Util.RequestParameterType.UserDefinedQueries)]
             public System.Collections.Generic.KeyValuePair<string, string>[] ParamsCollecetion { get; set; }
 
             public System.Uri Build()

--- a/Src/Support/GoogleApis.Tests/Apis/Requests/Parameters/ParameterUtilsTest.cs
+++ b/Src/Support/GoogleApis.Tests/Apis/Requests/Parameters/ParameterUtilsTest.cs
@@ -30,13 +30,16 @@ namespace Google.Apis.Tests.Apis.Requests
     {
         private class TestRequestUrl
         {
-            [Google.Apis.Util.RequestParameterAttribute("first_query_param", Google.Apis.Util.RequestParameterType.Query)]
+            [Google.Apis.Util.RequestParameterAttribute("first_query_param", 
+                Google.Apis.Util.RequestParameterType.Query)]
             public string FirstParam { get; set; }
 
-            [Google.Apis.Util.RequestParameterAttribute("second_query_param", Google.Apis.Util.RequestParameterType.Query)]
+            [Google.Apis.Util.RequestParameterAttribute("second_query_param", 
+                Google.Apis.Util.RequestParameterType.Query)]
             public string SecondParam { get; set; }
 
-            [Google.Apis.Util.RequestParameterAttribute("query_param_attribute_name", Google.Apis.Util.RequestParameterType.UserDefinedQueries)]
+            [Google.Apis.Util.RequestParameterAttribute("query_param_attribute_name", 
+                Google.Apis.Util.RequestParameterType.UserDefinedQueries)]
             public List<KeyValuePair<string, string>> ParamsCollection { get; set; }
 
             public System.Uri Build()
@@ -65,17 +68,15 @@ namespace Google.Apis.Tests.Apis.Requests
 
             var result = request.Build().AbsoluteUri;
 
-            //parameter was given a name and a value, so both appear in the uri
+            //Parametera were given a name and a value, so both appear in the URI.
             Assert.That(result, Contains.Substring("first_query_param=firstOne"));
-            
-            //parameter was given value only, so the name is the name of the property in lower case
             Assert.That(result, Contains.Substring("second_query_param=secondOne"));
 
-            //custom parameters are key value pairs representing parameter names and values respectively
+            //Custom parameters are key value pairs representing parameter names and values respectively.
             Assert.That(result, Contains.Substring("customParam1=customVal1"));
             Assert.That(result, Contains.Substring("customParam2=customVal2"));
 
-            //assert that the parameter name for the custom parameters does not carry through to the result
+            //The parameter name for the custom parameters does not carry through to the resulting URI.
             Assert.IsFalse(result.Contains("query_param_attribute_name"));
         }
     }

--- a/Src/Support/GoogleApis.Tests/GoogleApis.Tests.csproj
+++ b/Src/Support/GoogleApis.Tests/GoogleApis.Tests.csproj
@@ -138,6 +138,7 @@
     <Compile Include="Apis\Requests\BatchRequestTest.cs" />
     <Compile Include="Apis\Requests\PageStreamerTest.cs" />
     <Compile Include="Apis\Requests\Parameters\ParameterCollectionTest.cs" />
+    <Compile Include="Apis\Requests\Parameters\ParameterUtilsTest.cs" />
     <Compile Include="Apis\Requests\Parameters\ParameterValidatorTest.cs" />
     <Compile Include="Apis\Requests\RequestBuilderTest.cs" />
     <Compile Include="Apis\Services\BaseClientServiceTest.cs" />


### PR DESCRIPTION
Picking up where [pull 650](https://github.com/google/google-api-dotnet-client/pull/650) failed and left off prior to the big changes and my bad commits, this add the ability for users to include their own custom query parameters when making an authorization URL. This is in response to [issue 638](https://github.com/google/google-api-dotnet-client/issues/638) at request of @peleyal.

By providing a KeyValuePair<string, string>[] for the UserDefinedQueryParams member of the GoogleAuthorizationCodeFlow.Initializer, this collection will be used to update the resulting url via Google.Apis.Requests.Parameters.ParameterUtils.IterateParameters().

An attempt at a unit test has been provided with /GoogleApis.Tests/Apis/Requests/Parameters/ParameterUtilsTest.cs

The initial build will fail due to the [issue with the logger](https://github.com/google/google-api-dotnet-client/pull/650#discussion-diff-49464086), which I'll detail via a note on the code line.