### PR TITLE
Add MyGet build support.

### DIFF
--- a/MyGet.ps1
+++ b/MyGet.ps1
@@ -1,0 +1,43 @@
+# Performs the build for MyGet and uploads the generated NuGet packages to
+# the "google-dotnet" feed.
+#
+# MyGet's build syncs the repo and subrepos, to build manually be sure to:
+# git submodule update --init ClientGenerator
+
+function PrintHeader($message) {
+    Write-Host "****************************************"
+    Write-Host $message
+    Write-Host "****************************************"
+}
+
+Write-Host ".NET Client Libraries, build shard $Env:BuildShard"
+
+# TODO(chrsmith): Document why we require VS v14 to build.
+[Environment]::SetEnvironmentVariable(
+    "VisualStudioVersion",
+    "14.0",
+    "User")
+
+$msbuild14 = "${Env:ProgramFiles(x86)}\MSBuild\14.0\Bin\MSBuild.exe"
+
+# Build the Support libraries.
+PrintHeader("Building SupportLibraries.proj")
+& $msbuild14 /m /nr:false SupportLibraries.proj
+
+# TODO(chrsmith): Run unit tests as applicable.
+# At HEAD we have some test failures due to portable libraries and the
+# venerable System.Net.Http.Primitives assembly.
+
+# Install dependent Python libraries.
+PrintHeader("Installing Python dependencies")
+python -V
+python -m ensurepip --upgrade
+python -m pip list
+python -m pip install django==1.7
+python -m pip install httplib2
+python -m pip install google-apputils
+python -m pip install google-api-python-client
+
+# Build the Generated code (i.e. the specific API clients).
+PrintHeader("Building GeneratedLibraries.proj")
+& $msbuild14 /m /nr:false GeneratedLibraries.proj

--- a/MyGet.ps1
+++ b/MyGet.ps1
@@ -12,7 +12,7 @@ function PrintHeader($message) {
 
 Write-Host ".NET Client Libraries, build shard $Env:BuildShard"
 
-# TODO(chrsmith): Document why we require VS v14 to build.
+# Just needs to be a version installed on the system.
 [Environment]::SetEnvironmentVariable(
     "VisualStudioVersion",
     "14.0",
@@ -21,7 +21,7 @@ Write-Host ".NET Client Libraries, build shard $Env:BuildShard"
 $msbuild14 = "${Env:ProgramFiles(x86)}\MSBuild\14.0\Bin\MSBuild.exe"
 
 # Build the Support libraries.
-PrintHeader("Building SupportLibraries.proj")
+PrintHeader "Building SupportLibraries.proj"
 & $msbuild14 /m /nr:false SupportLibraries.proj
 
 # TODO(chrsmith): Run unit tests as applicable.
@@ -29,7 +29,7 @@ PrintHeader("Building SupportLibraries.proj")
 # venerable System.Net.Http.Primitives assembly.
 
 # Install dependent Python libraries.
-PrintHeader("Installing Python dependencies")
+PrintHeader "Installing Python dependencies"
 python -V
 python -m ensurepip --upgrade
 python -m pip list
@@ -39,5 +39,5 @@ python -m pip install google-apputils
 python -m pip install google-api-python-client
 
 # Build the Generated code (i.e. the specific API clients).
-PrintHeader("Building GeneratedLibraries.proj")
+PrintHeader "Building GeneratedLibraries.proj"
 & $msbuild14 /m /nr:false GeneratedLibraries.proj

--- a/MyGet.ps1
+++ b/MyGet.ps1
@@ -13,11 +13,7 @@ function PrintHeader($message) {
 Write-Host ".NET Client Libraries, build shard $Env:BuildShard"
 
 # Just needs to be a version installed on the system.
-[Environment]::SetEnvironmentVariable(
-    "VisualStudioVersion",
-    "14.0",
-    "User")
-
+$Env:VisualStudioVersion = "14.0"
 $msbuild14 = "${Env:ProgramFiles(x86)}\MSBuild\14.0\Bin\MSBuild.exe"
 
 # Build the Support libraries.


### PR DESCRIPTION
This PR adds a `MyGet.ps1` script file in the repository's root folder, which will be ran on the MyGet build machine.

I've confirmed that this all works, modulo a transient error where the build takes > 30 minutes and gets killed. (Publishing 141 packages can take a while.)

I'll try to get to clean a few things up, such as enabling Unit Testing as part of the build. However, it appears our Unit Tests are broken in HEAD due to the assembly load problems for `System.Net.Http.Primitives.dll`.

/cc @mmdriley 