### PR TITLE
Fix null pointer exception in HandleResponseAsync.

### DIFF
--- a/Src/Support/GoogleApis.Auth/OAuth2/ServiceCredential.cs
+++ b/Src/Support/GoogleApis.Auth/OAuth2/ServiceCredential.cs
@@ -173,11 +173,14 @@ namespace Google.Apis.Auth.OAuth2
 
         #region IHttpUnsuccessfulResponseHandler
 
-        // DO NOT SUBMIT UNTIL THIS IS DONE!
-        // TODO(chrsmith): Document this method, and the reason for the code
-        // below.
+        /// <summary>
+        /// Decorates unsuccessful responses, returns true if the response gets modified.
+        /// See IHttpUnsuccessfulResponseHandler for more information. 
+        /// </summary>
         public async Task<bool> HandleResponseAsync(HandleUnsuccessfulResponseArgs args)
         {
+            // If the response was unauthorized, request a new access token so that the original
+            // request can be retried.
             // TODO(peleyal): check WWW-Authenticate header.
             if (args.Response.StatusCode == HttpStatusCode.Unauthorized)
             {

--- a/Src/Support/GoogleApis.Auth/OAuth2/ServiceCredential.cs
+++ b/Src/Support/GoogleApis.Auth/OAuth2/ServiceCredential.cs
@@ -173,12 +173,21 @@ namespace Google.Apis.Auth.OAuth2
 
         #region IHttpUnsuccessfulResponseHandler
 
+        // DO NOT SUBMIT UNTIL THIS IS DONE!
+        // TODO(chrsmith): Document this method, and the reason for the code
+        // below.
         public async Task<bool> HandleResponseAsync(HandleUnsuccessfulResponseArgs args)
         {
             // TODO(peleyal): check WWW-Authenticate header.
             if (args.Response.StatusCode == HttpStatusCode.Unauthorized)
             {
-                return !Object.Equals(Token.AccessToken, AccessMethod.GetAccessToken(args.Request))
+                bool tokensEqual = false;
+                if (Token != null)
+                {
+                    tokensEqual = Object.Equals(
+                        Token.AccessToken, AccessMethod.GetAccessToken(args.Request));
+                }
+                return !tokensEqual
                     || await RequestAccessTokenAsync(args.CancellationToken).ConfigureAwait(false);
             }
 


### PR DESCRIPTION
If presenting invalid credentials in a JSON file, the Token property will be null. This reseulted in a null pointer exception at runtime. This unfortunately prevented a more meaningful RequestError "Invalid Credentials [401]" from being displayed.

Fixes issue #658.

@peleyal , would you mind reviewing this? The fix is ultra-simple. But I could use your help understanding what the `OAuth2\ServiceCredential.cs`'s `HandleResponseAsync` method does. It seems like it deserves a doc comment. I just don't know what to write.