### PR TITLE
Initial commit of EasyRepro solution to aid debugging.

### DIFF
--- a/Src/Repro/EasyRepro.sln
+++ b/Src/Repro/EasyRepro.sln
@@ -1,0 +1,27 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.24720.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EasyRepro", "EasyRepro\EasyRepro.csproj", "{D9D53004-9DAD-41AE-BA24-CE8747DA67AE}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{BAF8D897-29C5-404E-9BC9-20A7CF0B4A09}"
+	ProjectSection(SolutionItems) = preProject
+		nuget.config = nuget.config
+	EndProjectSection
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{D9D53004-9DAD-41AE-BA24-CE8747DA67AE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D9D53004-9DAD-41AE-BA24-CE8747DA67AE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D9D53004-9DAD-41AE-BA24-CE8747DA67AE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D9D53004-9DAD-41AE-BA24-CE8747DA67AE}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/Src/Repro/EasyRepro/App.config
+++ b/Src/Repro/EasyRepro/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+    </startup>
+</configuration>

--- a/Src/Repro/EasyRepro/EasyRepro.csproj
+++ b/Src/Repro/EasyRepro/EasyRepro.csproj
@@ -1,0 +1,61 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{D9D53004-9DAD-41AE-BA24-CE8747DA67AE}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>EasyRepro</RootNamespace>
+    <AssemblyName>EasyRepro</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="README.md" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Src/Repro/EasyRepro/Program.cs
+++ b/Src/Repro/EasyRepro/Program.cs
@@ -1,0 +1,28 @@
+﻿using System;
+
+namespace EasyRepro
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine(".NET Client Libraries Easy Repro Project");
+
+            try
+            {
+                ReproduceProblem();
+            } catch (Exception ex)
+            {
+                Console.WriteLine("Unhandled Exception:\n{0}", ex);
+            }
+
+            Console.WriteLine("(press any key to continue)");
+            Console.ReadKey();
+        }
+
+        static void ReproduceProblem()
+        {
+            // TODO: Put problem here.
+        }
+    }
+}

--- a/Src/Repro/EasyRepro/Properties/AssemblyInfo.cs
+++ b/Src/Repro/EasyRepro/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("EasyRepro")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("EasyRepro")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("d9d53004-9dad-41ae-ba24-ce8747da67ae")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Src/Repro/EasyRepro/README.md
+++ b/Src/Repro/EasyRepro/README.md
@@ -1,0 +1,122 @@
+﻿# Easy Repro: Skeleton project for reproducing bugs
+
+This project serves as a way to test integration-level changes to the Google
+.NET client libraries, without needing to first publish binaries to NuGet.
+
+This works through a `nuget.config` file that picks up the needed dependencies
+from the local machine. (Instead of using the public NuGet packages.)
+
+This project is not part of the regular build and not ran as part of the
+release testing. It's only for debugging purposes. Read: this is not a
+regression test suite. Rather, it is a debugging tool.
+
+`TODO(chrsmith): Document how to build the Support libraries with DEBUG.`
+
+Read this document top to bottom and be sure to follow along with each
+and every step. Unfortunately there are a lot of subtle things you need
+to get right.
+
+## Getting Started
+
+The first thing to do is to ensure you have a clean enlistment. Create a new
+git branch as applicable and delete any untracked files. (e.g. previously
+built NuGet packages.)
+
+````
+git clean -dxf
+````
+
+## How to Build
+
+To build the .NET Client Libraries, run the following commands from PowerShell.
+You will do this a few times while setting up your local issue repro.
+
+````
+$msbuild14 = "C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe"
+& $msbuild14 /m /nr:false SupportLibraries.proj
+& $msbuild14 /m /nr:false GeneratedLibraries.proj
+````
+
+## Getting Started
+
+The first thing you need to do is make sure NuGet and the `nuget.config` are
+correct. Edit `nuget.config` and add the file path where you build the client
+libraies. This is dependent on where your repository is located on disk.
+
+`TODO(chrsmith): Confirm this will work for multiple developers.`
+
+````
+notepad .\Src\Repro\nuget.config
+````
+
+Next you should probably delete the local NuGet package caches, since they
+contain unknown versions of the NuGet packages.
+
+````
+Remove-Item -Force -Recurse C:\Users\$Env:UserName\AppData\Local\NuGet\Cache
+Remove-Item -Force -Recurse C:\Users\$Env:UserName\.nuget\packages\
+````
+
+At this point you can begin creating a small program to reproduce any issues in
+the .NET client libraries.
+
+1. Build the libraries (both Suppport and Generated).
+1. Open the `EasyRepo` project.
+1. Click the gear in the _Package Manager Console_, and confirm that The
+   two NuGet package sources "Private Support Libraries" and "Private Generated
+   Libraries" are available. (These come from `nuget.config` next to the
+   Solution file.)
+1. Disable all other NuGet package sources.
+1. Use the Visual Studio Package Manager Console to add any necessary
+   dependencies. e.g. `Install-Package Google.Apis.Calendar.v3`.
+   - If you run into errors with `Microsoft.Threading.Tasks` missing, enable
+     the non-local NuGet sources and `Install-Package Microsoft.Bcl.Async`. I
+     believe this has to do with the project template used, and not the client
+     libraries.
+   - @chrsmith got this to work without any problems. But if non-Google
+     packages such as `Zlib.Portable` or `BouncyCastle.Crypto` cannot be found
+     then consider checking them into the repo in `.nupkg` format.
+
+At this point you have EasyRepo referencing locally built NuGet packages.
+Update `Program.cs` to reproduce the failure you are investigating.
+
+## Testing Fixes
+
+By referencing the locally built NuGet packages, debugging should be much
+easier since you have PDBs that match the source on disk.
+
+Once you have figured out what needs to be tweaked, you need to run a few
+steps so that the `EasyRepo` project can pick up your changes.
+
+1. Rebuild the client libraries. (Perhaps only `SupportLibraries.proj` if the
+   changes don't impact the generated libraries.)
+1. From the PowerShell delete the previous NuGet packages:
+   `Remove-Item .\Src\Repro\packages\Google* -Recurse`
+1. Delete NuGet package caches too:
+   `Remove-Item -Force -Recurse C:\Users\$Env:UserName\AppData\Local\NuGet\Cache`
+   `Remove-Item -Force -Recurse C:\Users\$Env:UserName\.nuget\packages\`
+1. Nuget restore the packages, which will pick up the newly built binaries:
+   `nuget restore .\Src\Repro\EasyRepro.sln`
+
+Now if you try to build `EasyRepo` you will get an error. This is expected.
+
+````
+Could not resolve this reference. Could not locate the assembly
+"Google.Apis, Version=1.10.0.35122, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL". Check to make sure the assembly exists on disk. If this reference is required by your code, you may get compilation errors.			
+````
+
+It is because you built a new version of `Google.Apis`, but the project
+references an older version. To fix this, select the relevante references in
+the `EasyRepro` project and in the Property Window set the "Specific Version"
+property from `True` to `False`. i.e. tell Visual Studio this is OK.
+
+Clean the project and and then Rebuild. You should now get a warning message
+suggesting you add an assembly redirect to the `app.config`. This is optional
+and can be ignored.
+
+At runtime you should see new behaviour from the client libraries, as they
+should contain your recent changes.
+
+NOTE: Every time you repeat this process, you must Clean the project before you
+build. Otherwise the updated NuGet binaries won't be put into the bindir, and
+you will get odd assembly load errors.

--- a/Src/Repro/nuget.config
+++ b/Src/Repro/nuget.config
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!-- chrsmith -->
+    <add key="Private Support Libraries"
+        value="C:\src\github.com\chrsmith\google-api-dotnet-client\NuPkgs\Support">
+    </add>
+    <add key="Private Generated Libraries"
+        value="C:\src\github.com\chrsmith\google-api-dotnet-client\NuPkgs\Generated">
+    </add>
+    <!--
+      We do NOT want to reach out to NuGet.org and get the official packages.
+      We only want to use those that are locally built.
+
+    <add key="Official NuGet.org"
+         value="https://api.nuget.org/v3/index.json">
+    </add>
+    -->
+  </packageSources>
+</configuration>


### PR DESCRIPTION
This PR adds a new folder `/Src/Repro`. This contains `EasyRepro.sln`, which is a project designed to make it easier to reproduce client library bugs on your local machine for debugging and testing. The ultimate goal is to speed up the turnaround time for customer issues and testing pull requests.

There is nothing special about the code other than `README.md` which documents how to actually go about building, testing, and debugging locally-built NuGet packages on your machine.

The steps aren't 100% foolproof yet. I wouldn't expect a Noogler to run through the steps and not run into problems. But it captures most of the process necessary for picking up the right NuGet packages from the right places.

Once things are stable, I imagine we'll want to add the folder to the `.gitignore` file so that any local modifications during debugging aren't picked up.

/cc @peleyal @mmdriley 