### PR TITLE
Fix build ordering in GeneratedLibraries.proj

### DIFF
--- a/GeneratedLibraries.proj
+++ b/GeneratedLibraries.proj
@@ -104,7 +104,7 @@
   </Target>
 
   <!-- Create NuGet packages with binaries built from generated projects. -->
-  <Target Name="Package" DependsOnTargets="BuildProjectList;Build"
+  <Target Name="Package" DependsOnTargets="Build;BuildProjectList"
       Condition="!Exists('NuPkgs\Generated')">
     <MakeDir Directories="NuPkgs\Generated" />
 


### PR DESCRIPTION
Invoking the Package target (or anything that depended on it, like the
default target Repackage) would invoke BuildProjectList before Build.
Build, in turn, is what invokes Generate, so we would try to build a
list of projects before guaranteeing the projects had actually been
generated. If Src/Generated had been deleted, BuildProjectList would
build an empty list, no projects would be built, and packaging would
fail.