### PR TITLE
Handle empty error responses in media upload/download

### DIFF
--- a/Src/Support/GoogleApis.Tests/Apis/Download/MediaDownloaderTest.cs
+++ b/Src/Support/GoogleApis.Tests/Apis/Download/MediaDownloaderTest.cs
@@ -314,11 +314,12 @@ namespace Google.Apis.Tests.Apis.Download
         }
 
         [Test]
-        public void Download_Error_PlaintextResponse()
+        [TestCase("Not Found")]
+        [TestCase("")]
+        public void Download_Error_PlaintextResponse(string responseText)
         {
             var downloadUri = "http://www.sample.com";
             var chunkSize = 100;
-            var responseText = "Not Found";
 
             var handler = new MultipleChunksMessageHandler { ErrorResponse = responseText };
             handler.StatusCode = HttpStatusCode.NotFound;

--- a/Src/Support/GoogleApis/Apis/[Media]/MediaApiErrorHandling.cs
+++ b/Src/Support/GoogleApis/Apis/[Media]/MediaApiErrorHandling.cs
@@ -45,9 +45,10 @@ namespace Google.Apis.Media
             string message = responseText;
             try
             {
-                parsedError = service.Serializer.Deserialize<StandardResponse<object>>(responseText).Error;
-                if (parsedError != null)
+                var parsedResponse = service.Serializer.Deserialize<StandardResponse<object>>(responseText);
+                if (parsedResponse != null && parsedResponse.Error != null)
                 {
+                    parsedError = parsedResponse.Error;
                     message = parsedError.ToString();
                 }
             }


### PR DESCRIPTION
Fixes issue #692.

(Apologies for this being necessary... I thought I'd covered all the bases in previous tests...)