### PR TITLE
Fix revision number of support libraries to 0

### DIFF
--- a/Src/Support/CommonAssemblyInfo.cs
+++ b/Src/Support/CommonAssemblyInfo.cs
@@ -21,7 +21,7 @@ using System.Reflection;
 [assembly: AssemblyCompany("Google Inc")]
 [assembly: AssemblyCopyright("Copyright 2016 Google Inc")]
 
-[assembly: AssemblyVersion("1.11.0.*")]
+[assembly: AssemblyVersion("1.11.0.0")]
 
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]


### PR DESCRIPTION
Otherwise the libraries built from the Net45 and Portable projects
end up with different versions and strongnames.