### PR TITLE
Revise README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,50 +3,39 @@
 ## Google APIs client Library for .NET  ##
 
 ## Description ##
-The Google APIs client library for .NET provides simple, flexible, and powerful access to Google APIs such as Drive, YouTube, Calendar, Storage and Analytics.
-
-The library supports OAuth2.0 authentication, and is able to generate strongly typed client libraries for Discovery-based services.
-
-Requirements 
-=================================
-* [.NET Framework 4.0](http://www.microsoft.com/en-us/download/details.aspx?id=17851)
-* [.NET Framework 4.5](http://www.microsoft.com/en-us/download/details.aspx?id=30653)
+The Google API client library for .NET enables access to Google APIs such as Drive, YouTube, Calendar, Storage and Analytics. The library supports OAuth2.0 authentication. Strongly-typed per-API libraries are generated using Google's [Discovery API](https://developers.google.com/discovery/).
 
 Supported Platforms
 =================================
 
+* .NET Framework 4.5
 * Windows Store apps
 * Windows Phone 8 and 8.1
 * Portable Class Libraries
+
+## Legacy Support
+
+We provide best-effort support for these platforms, but new features may not be available.
+
+* .NET Framework 4.0
+* Silverlight 5.0
 
 Developer Documentation
 =================================
 
 * [Google API client Library for .NET - Get Started](https://developers.google.com/api-client-library/dotnet/get_started)
-* [supported APIs](https://developers.google.com/api-client-library/dotnet/apis/)
-* [google-api-dotnet-client Announcements](http://google-api-dotnet-client.blogspot.dk/)
+* [Supported APIs](https://developers.google.com/api-client-library/dotnet/apis/)
+
 
 NuGet Packages
 =================================
 
-To make it easer for you to develop with the Google APIs using the Google API client Library for .NET we have released a number of NuGet packages. A full list of all the avaliable packages can be found at the [Google.APIs NuGet](https://www.nuget.org/packages?q=google.apis&sortOrder=relevance) page.
+To make it easer for you to develop with the Google APIs using the Google API client Library for .NET we have released a number of NuGet packages. The libraries published by Google are owned by [google-apis-packages](https://www.nuget.org/profiles/google-apis-packages).
 
-Source for APIs
+API-specific Libraries
 =================================
 
-The source code for the individual Google APIs is programmatically generated using the [Discovery API](https://developers.google.com/discovery/). <br/> Using the following formula, you can find the source for any of the API dlls:
-<br/>
-https://developers.google.com/resources/api-libraries/download/API_NAME/API_VERSION/csharp <br/>
-
-Replace API_NAME with the name of the API. <br/>
-Replace API_VERSION with the version of the API.
-
-Examples:
-
-* [https://developers.google.com/resources/api-libraries/download/analytics/v3/csharp](https://developers.google.com/resources/api-libraries/download/analytics/v3/csharp) for Analytics v3
-* [https://developers.google.com/resources/api-libraries/download/drive/v2/csharp](https://developers.google.com/resources/api-libraries/download/drive/v2/csharp) for Drive v2
-
-Tip: If you are unsure of the name and/or the version of the API, you can check it using the Discovery API at the bottom of the [Discovery list](https://developers.google.com/discovery/v1/reference/apis/list) page.
+The generator that produces the source code for API-specific libraries is in `ClientGenerator/`. The most recently generated code is available in `Src/Generated/`, and the discovery documents from which that code was generated are in `DiscoveryJson/`.
 
 Support Forums
 =================================


### PR DESCRIPTION
Call out that .NET 4.0 and Silverlight 5.0 are supported best-effort.

Fix link to Google APIs packages on NuGet.org

Describe where to find library source code in the repository.

Remove a reference to the announcements blog now that it [points back at GitHub](http://google-api-dotnet-client.blogspot.com/).