### PR TITLE
Overhaul of MediaDownloader: simpler, handles `Content-Encoding: gzip`

### DIFF
--- a/Src/Support/GoogleApis.Auth.DotNet4.Tests/GoogleApis.Auth.PlatformServices.Tests_Net45.csproj
+++ b/Src/Support/GoogleApis.Auth.DotNet4.Tests/GoogleApis.Auth.PlatformServices.Tests_Net45.csproj
@@ -56,8 +56,8 @@
       <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.2.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.2.1\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/Src/Support/GoogleApis.Auth.DotNet4.Tests/packages.config
+++ b/Src/Support/GoogleApis.Auth.DotNet4.Tests/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
-  <package id="NUnit" version="2.6.3" targetFramework="net45" />
+  <package id="NUnit" version="3.2.1" targetFramework="net45" />
 </packages>

--- a/Src/Support/GoogleApis.Auth.Tests/GoogleApis.Auth.Tests.csproj
+++ b/Src/Support/GoogleApis.Auth.Tests/GoogleApis.Auth.Tests.csproj
@@ -56,8 +56,8 @@
       <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.2.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.2.1\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/Src/Support/GoogleApis.Auth.Tests/OAuth2/BearerTokenTests.cs
+++ b/Src/Support/GoogleApis.Auth.Tests/OAuth2/BearerTokenTests.cs
@@ -52,7 +52,7 @@ namespace Google.Apis.Auth.OAuth2
             var request = new HttpRequestMessage();
             request.Headers.Authorization = new AuthenticationHeaderValue("a", "1");
             var accessToken = new BearerToken.AuthorizationHeaderAccessMethod().GetAccessToken(request);
-            Assert.IsNullOrEmpty(accessToken);
+            Assert.That(accessToken, Is.Null.Or.Empty);
 
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "abc");
             accessToken = new BearerToken.AuthorizationHeaderAccessMethod().GetAccessToken(request);
@@ -81,12 +81,12 @@ namespace Google.Apis.Auth.OAuth2
             // No query parameter at all.
             var request = new HttpRequestMessage(HttpMethod.Get, new Uri("https://sample.com"));
             var accessToken = new BearerToken.QueryParameterAccessMethod().GetAccessToken(request);
-            Assert.IsNullOrEmpty(accessToken);
+            Assert.That(accessToken, Is.Null.Or.Empty);
 
             // Different query parameter.
             request = new HttpRequestMessage(HttpMethod.Get, new Uri("https://sample.com?a=1"));
             accessToken = new BearerToken.QueryParameterAccessMethod().GetAccessToken(request);
-            Assert.IsNullOrEmpty(accessToken);
+            Assert.That(accessToken, Is.Null.Or.Empty);
 
             // One query parameter and it's access_token.
             request = new HttpRequestMessage(HttpMethod.Get, new Uri("https://sample.com?a=1&access_token=abc"));

--- a/Src/Support/GoogleApis.Auth.Tests/packages.config
+++ b/Src/Support/GoogleApis.Auth.Tests/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
-  <package id="NUnit" version="2.6.3" targetFramework="net45" />
+  <package id="NUnit" version="3.2.1" targetFramework="net45" />
 </packages>

--- a/Src/Support/GoogleApis.Core/Apis/Util/UriPatcher.cs
+++ b/Src/Support/GoogleApis.Core/Apis/Util/UriPatcher.cs
@@ -54,9 +54,9 @@ namespace Google.Apis.Util
     // As a class library, we can't control app.config or the entry assembly, so we can't take
     // either approach. Instead, we resort to reflection trickery to try to solve these problems
     // if we detect they exist. Sorry.
-    internal static class UriPatcher
+    public static class UriPatcher
     {
-        internal static void PatchUriQuirks()
+        public static void PatchUriQuirks()
         {
             var uriParser = typeof(System.Uri).Assembly.GetType("System.UriParser");
             if (uriParser == null) { return; }

--- a/Src/Support/GoogleApis.Tests/Apis/Requests/ClientServiceRequestTest.cs
+++ b/Src/Support/GoogleApis.Tests/Apis/Requests/ClientServiceRequestTest.cs
@@ -41,7 +41,7 @@ namespace Google.Apis.Tests.Apis.Requests
     [TestFixture]
     public class ClientServiceRequestTest
     {
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void SetUp()
         {
             // Uncomment to enable logging during tests

--- a/Src/Support/GoogleApis.Tests/Apis/Upload/ResumableUploadTest.cs
+++ b/Src/Support/GoogleApis.Tests/Apis/Upload/ResumableUploadTest.cs
@@ -46,7 +46,7 @@ nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit 
 eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit 
 anim id est laborum.";
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void SetUp()
         {
             // Change the false parameter to true if you want to enable logging during tests.

--- a/Src/Support/GoogleApis.Tests/GoogleApis.Tests.csproj
+++ b/Src/Support/GoogleApis.Tests/GoogleApis.Tests.csproj
@@ -84,8 +84,8 @@
       <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.2.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.2.1\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/Src/Support/GoogleApis.Tests/packages.config
+++ b/Src/Support/GoogleApis.Tests/packages.config
@@ -3,6 +3,6 @@
   <package id="log4net" version="2.0.3" targetFramework="net45" />
   <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
-  <package id="NUnit" version="2.6.3" targetFramework="net45" />
+  <package id="NUnit" version="3.2.1" targetFramework="net45" />
   <package id="Zlib.Portable.Signed" version="1.11.0" targetFramework="net45" />
 </packages>

--- a/travis.sh
+++ b/travis.sh
@@ -4,8 +4,8 @@
 set -e
 
 # grab nunit runners
-nuget install NUnit.Runners -Version 2.6.4 -OutputDirectory testrunner
-NUNIT="${PWD}/testrunner/NUnit.Runners.2.6.4/tools/nunit-console.exe"
+nuget install NUnit.ConsoleRunner -Version 3.2.1 -OutputDirectory testrunner
+NUNIT="${PWD}/testrunner/NUnit.ConsoleRunner.3.2.1/tools/nunit3-console.exe"
 
 cd Src/Support
 


### PR DESCRIPTION
Today, MediaDownloader downloads content in chunks by sending one HTTP
request per chunk. Each request has an appropriate `Range` header set.

One consequence of this approach is that when users try to download
content served with `Content-Encoding: gzip` and that content happens
to be more than one chunk large, the download will fail with an error
like:

`System.IO.InvalidDataException: The magic number in GZip header is not correct. Make sure you are passing in a GZip stream.`

`HttpClientHandler` is trying to do the decoding for us because we set
its `AutomaticDecompression` property, but the decoding fails because
we've requested a range of data in the middle of a GZip stream.

Users can encounter this when downloading files from GCS that were
uploaded with `gsutil -Z`.

I considered asking the server to send us already-decompressed content
by not setting the `Accept-Encoding` header in our requests. Aside from
wasting  customers' bandwidth, this turns out not to work: GCS ignores
the header and returns gzipped data regardless.

I also briefly considered special case handling for GZip downloads,
e.g. setting a huge ChunkSize or buffering intermediate results.

Instead, I decided to make things simpler and more flexible by only
making one request per download. As far as I can tell, there wasn't any
benefit to the multiple-request approach. It probably hurt performance
because we interrupted established transfers.

To avoid any impact on clients, ChunkSize is retained. Now it indicates
the granularity at which content should be written to the output stream
and our callers will be notified of progress. I've verified that the
progress events the caller sees are the same for both implementations.

I could not find a way to test this in MediaDownloaderTest as it was.
We were mocking out the request side of HttpClient and not exercising
any of the code that is actually responsible for transport concerns
like compression. My solution was to rewrite MediaDownloaderTest to
use a local HTTP server that serves the responses we need to exercise
the behavior under test. A lot of code changed, but I really think the
resulting test is easier to read and less fragile than before.

The old MediaDownloader implementation passes the new tests (except
the one that returns GZip content). Only minimal modifications to the
old tests are necessary for them to pass on the new MediaDownloader --
mostly removing those tests' baked-in assumptions about how many
requests would be made and for what ranges.

While I was there, I replaced some fiddly Query string manipulation
code in MediaDownloader that took apart the Query string only to
immediately reassembly it. That removed MediaDownloader's use of
RequestBuilder. Since the latter is what we trusted to bring in our
URI hacks, I made `PatchUriQuirks` public and added a class
initializer to MediaDownloader to use it.