### PR TITLE
Make GoogleCredential implement ICredential

### DIFF
--- a/Src/Support/GoogleApis.Auth.DotNet4/OAuth2/GoogleCredential.cs
+++ b/Src/Support/GoogleApis.Auth.DotNet4/OAuth2/GoogleCredential.cs
@@ -32,7 +32,7 @@ namespace Google.Apis.Auth.OAuth2
     /// See <see cref="GetApplicationDefaultAsync"/> for the credential retrieval logic.
     /// </para>
     /// </summary>
-    public class GoogleCredential : IConfigurableHttpClientInitializer, ITokenAccess
+    public class GoogleCredential : ICredential
     {
         /// <summary>Provider implements the logic for creating the application default credential.</summary>
         private static DefaultCredentialProvider defaultCredentialProvider = new DefaultCredentialProvider();


### PR DESCRIPTION
ICredential is just a union of IConfigurableHttpClientInitializer and
ITokenAccess, both of which were already explicitly implemented. This
change just tidies things up.

Fixes issue #721.

// @chrisdunelm 