### PR TITLE
Propagate errors from the initial upload request more appropriately.

### DIFF
--- a/Src/Support/GoogleApis/Apis/[Media]/Upload/ResumableUpload.cs
+++ b/Src/Support/GoogleApis/Apis/[Media]/Upload/ResumableUpload.cs
@@ -383,6 +383,7 @@ namespace Google.Apis.Upload
             {
                 Logger.Error(ex, "MediaUpload - Exception occurred while initializing the upload");
                 UpdateProgress(new ResumableUploadProgress(ex, BytesServerReceived));
+                return Progress;
             }
 
             return await UploadCoreAsync(cancellationToken).ConfigureAwait(false);
@@ -491,7 +492,12 @@ namespace Google.Apis.Upload
         {
             HttpRequestMessage request = CreateInitializeRequest();
             var response = await Service.HttpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
-            return response.EnsureSuccessStatusCode().Headers.Location;
+            
+            if (!response.IsSuccessStatusCode)
+            {
+                throw await MediaApiErrorHandling.ExceptionForResponseAsync(Service, response).ConfigureAwait(false);
+            }
+            return response.Headers.Location;
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes issue #456.

// cc @mmdriley who may be able to comment on how useful it would be to migrate the upload tests to use an HttpListener.