### PR TITLE
Make each of the *.Tests projects runnable

### DIFF
--- a/Src/Support/GoogleApis.Auth.DotNet4.Tests/GoogleApis.Auth.PlatformServices.Tests_Net45.csproj
+++ b/Src/Support/GoogleApis.Auth.DotNet4.Tests/GoogleApis.Auth.PlatformServices.Tests_Net45.csproj
@@ -5,7 +5,7 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{5A731729-8E99-4930-AE77-FA3524673DA3}</ProjectGuid>
-    <OutputType>Library</OutputType>
+    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Google.Apis.Auth</RootNamespace>
     <AssemblyName>Google.Apis.Auth.DotNet4.Tests</AssemblyName>
@@ -15,6 +15,7 @@
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <TargetFrameworkProfile />
+    <StartArguments>--wait</StartArguments>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -60,6 +61,10 @@
       <HintPath>..\packages\NUnit.3.2.1\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="nunitlite, Version=3.2.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnitLite.3.2.1\lib\net45\nunitlite.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net" />
@@ -74,6 +79,7 @@
   <ItemGroup>
     <Compile Include="OAuth2\GoogleCredentialTests.cs" />
     <Compile Include="OAuth2\DefaultCredentialProviderTests.cs" />
+    <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="..\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>

--- a/Src/Support/GoogleApis.Auth.DotNet4.Tests/Program.cs
+++ b/Src/Support/GoogleApis.Auth.DotNet4.Tests/Program.cs
@@ -1,0 +1,41 @@
+// ***********************************************************************
+// Copyright (c) 2015 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using NUnitLite;
+
+namespace NUnitLite.Tests
+{
+    public class Program
+    {
+        /// <summary>
+        /// The main program executes the tests. Output may be routed to
+        /// various locations, depending on the arguments passed.
+        /// </summary>
+        /// <remarks>Run with --help for a full list of arguments supported</remarks>
+        /// <param name="args"></param>
+        public static int Main(string[] args)
+        {
+            return new AutoRun().Execute(args);
+        }
+    }
+}

--- a/Src/Support/GoogleApis.Auth.DotNet4.Tests/packages.config
+++ b/Src/Support/GoogleApis.Auth.DotNet4.Tests/packages.config
@@ -3,4 +3,5 @@
   <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="NUnit" version="3.2.1" targetFramework="net45" />
+  <package id="NUnitLite" version="3.2.1" targetFramework="net45" />
 </packages>

--- a/Src/Support/GoogleApis.Auth.Tests/GoogleApis.Auth.Tests.csproj
+++ b/Src/Support/GoogleApis.Auth.Tests/GoogleApis.Auth.Tests.csproj
@@ -5,7 +5,7 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{548D6C9B-A97B-4316-91AC-9AAD35202884}</ProjectGuid>
-    <OutputType>Library</OutputType>
+    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Google.Apis.Auth</RootNamespace>
     <AssemblyName>Google.Apis.Auth.Tests</AssemblyName>
@@ -15,6 +15,7 @@
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <TargetFrameworkProfile />
+    <StartArguments>--wait</StartArguments>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -60,6 +61,10 @@
       <HintPath>..\packages\NUnit.3.2.1\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="nunitlite, Version=3.2.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnitLite.3.2.1\lib\net45\nunitlite.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net" />
@@ -82,6 +87,7 @@
     <Compile Include="OAuth2\Requests\RefreshTokenRequestTests.cs" />
     <Compile Include="OAuth2\Responses\AuthorizationCodeResponseUrlTests.cs" />
     <Compile Include="OAuth2\Responses\TokenResponseTests.cs" />
+    <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="..\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>

--- a/Src/Support/GoogleApis.Auth.Tests/Program.cs
+++ b/Src/Support/GoogleApis.Auth.Tests/Program.cs
@@ -1,0 +1,41 @@
+// ***********************************************************************
+// Copyright (c) 2015 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using NUnitLite;
+
+namespace NUnitLite.Tests
+{
+    public class Program
+    {
+        /// <summary>
+        /// The main program executes the tests. Output may be routed to
+        /// various locations, depending on the arguments passed.
+        /// </summary>
+        /// <remarks>Run with --help for a full list of arguments supported</remarks>
+        /// <param name="args"></param>
+        public static int Main(string[] args)
+        {
+            return new AutoRun().Execute(args);
+        }
+    }
+}

--- a/Src/Support/GoogleApis.Auth.Tests/packages.config
+++ b/Src/Support/GoogleApis.Auth.Tests/packages.config
@@ -3,4 +3,5 @@
   <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="NUnit" version="3.2.1" targetFramework="net45" />
+  <package id="NUnitLite" version="3.2.1" targetFramework="net45" />
 </packages>

--- a/Src/Support/GoogleApis.Tests/GoogleApis.Tests.csproj
+++ b/Src/Support/GoogleApis.Tests/GoogleApis.Tests.csproj
@@ -6,7 +6,7 @@
     <ProductVersion>8.0.50727</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{9A8AA9EF-6904-43D8-8A26-0AB62069C2DC}</ProjectGuid>
-    <OutputType>Library</OutputType>
+    <OutputType>Exe</OutputType>
     <RootNamespace>Google.Apis.Tests</RootNamespace>
     <AssemblyName>Google.Apis.Tests</AssemblyName>
     <FileUpgradeFlags>
@@ -33,6 +33,7 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <StartArguments>--wait</StartArguments>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -88,6 +89,10 @@
       <HintPath>..\packages\NUnit.3.2.1\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="nunitlite, Version=3.2.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnitLite.3.2.1\lib\net45\nunitlite.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data.Linq" />
     <Reference Include="System.Data" />
@@ -118,6 +123,7 @@
     <Compile Include="Apis\Utils\StringValueAttributeTest.cs" />
     <Compile Include="Apis\Utils\RepeatableTest.cs" />
     <Compile Include="ApplicationContextTests.cs" />
+    <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="..\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>

--- a/Src/Support/GoogleApis.Tests/Program.cs
+++ b/Src/Support/GoogleApis.Tests/Program.cs
@@ -1,0 +1,41 @@
+// ***********************************************************************
+// Copyright (c) 2015 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using NUnitLite;
+
+namespace NUnitLite.Tests
+{
+    public class Program
+    {
+        /// <summary>
+        /// The main program executes the tests. Output may be routed to
+        /// various locations, depending on the arguments passed.
+        /// </summary>
+        /// <remarks>Run with --help for a full list of arguments supported</remarks>
+        /// <param name="args"></param>
+        public static int Main(string[] args)
+        {
+            return new AutoRun().Execute(args);
+        }
+    }
+}

--- a/Src/Support/GoogleApis.Tests/packages.config
+++ b/Src/Support/GoogleApis.Tests/packages.config
@@ -4,5 +4,6 @@
   <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="NUnit" version="3.2.1" targetFramework="net45" />
+  <package id="NUnitLite" version="3.2.1" targetFramework="net45" />
   <package id="Zlib.Portable.Signed" version="1.11.0" targetFramework="net45" />
 </packages>

--- a/travis.sh
+++ b/travis.sh
@@ -16,6 +16,6 @@ xbuild /p:Configuration=ReleaseTravis GoogleApisClient.sln
 OUTDIR=bin/ReleaseSigned
 
 mono "${NUNIT}" \
-    "GoogleApis.Tests/${OUTDIR}/Google.Apis.Tests.dll" \
-    "GoogleApis.Auth.Tests/${OUTDIR}/Google.Apis.Auth.Tests.dll" \
-    "GoogleApis.Auth.DotNet4.Tests/${OUTDIR}/Google.Apis.Auth.DotNet4.Tests.dll"
+    "GoogleApis.Tests/${OUTDIR}/Google.Apis.Tests.exe" \
+    "GoogleApis.Auth.Tests/${OUTDIR}/Google.Apis.Auth.Tests.exe" \
+    "GoogleApis.Auth.DotNet4.Tests/${OUTDIR}/Google.Apis.Auth.DotNet4.Tests.exe"


### PR DESCRIPTION
We change each test project from .dll to .exe and install NUnitLite,
which adds a console runner stub in Program.cs. Now running any of these
projects (right-click, "Debug", "Start New Instance"; or "Set as StartUp
Project" and F5) will actually run the tests.

Among other things, this enables easy test debugging with breakpoints!

Of course, you can still run the tests by pointing NUnit at the .exes.

For convenience, I added the "--wait" parameter in all configurations so
the console window with test results stays around.

I tried leaving the projects as .dlls and setting StartProgram, etc.
but I was unable to get that working reliably with relative paths.