### PR TITLE
Preventing OutOfRangeArgument exception when login in windows phone

### DIFF
--- a/Src/Support/GoogleApis.Auth.WP/OAuth2/WebAuthenticationBrokerUserControl.xaml.cs
+++ b/Src/Support/GoogleApis.Auth.WP/OAuth2/WebAuthenticationBrokerUserControl.xaml.cs
@@ -61,8 +61,11 @@ namespace Google.Apis.Auth.OAuth2
             // The code or the error should be received by localhost.
             if (e.Uri.Host == "localhost")
             {
-                var query = e.Uri.Query.Substring(1);
-                tcsAuthorizationCodeResponse.TrySetResult(new AuthorizationCodeResponseUrl(query));
+                if (!string.IsNullOrEmpty(e.Uri.Query))
+                {
+                    var query = e.Uri.Query.Substring(1);
+                    tcsAuthorizationCodeResponse.TrySetResult(new AuthorizationCodeResponseUrl(query));
+                }
             }
         }
 


### PR DESCRIPTION
Not that sure if this happens to everyone, but I experienced crash whenever attempting OAuth in windows phone 8