### PR TITLE
Added 'id_token' property to TokenResponse

### DIFF
--- a/Src/Support/GoogleApis.Auth/OAuth2/Responses/TokenResponse.cs
+++ b/Src/Support/GoogleApis.Auth/OAuth2/Responses/TokenResponse.cs
@@ -55,7 +55,7 @@ namespace Google.Apis.Auth.OAuth2.Responses
         public string Scope { get; set; }
 
         /// <summary>
-        /// Gets or sets the id_token
+        /// Gets or sets the id_token, which is a JSON Web Token (JWT) as specified in http://tools.ietf.org/html/draft-ietf-oauth-json-web-token
         /// </summary>
         [Newtonsoft.Json.JsonPropertyAttribute("id_token")]
         public string IdToken { get; set; }

--- a/Src/Support/GoogleApis.Auth/OAuth2/Responses/TokenResponse.cs
+++ b/Src/Support/GoogleApis.Auth/OAuth2/Responses/TokenResponse.cs
@@ -54,6 +54,12 @@ namespace Google.Apis.Auth.OAuth2.Responses
         [Newtonsoft.Json.JsonPropertyAttribute("scope")]
         public string Scope { get; set; }
 
+        /// <summary>
+        /// Gets or sets the id_token
+        /// </summary>
+        [Newtonsoft.Json.JsonPropertyAttribute("id_token")]
+        public string IdToken { get; set; }
+
         /// <summary>The date and time that this token was issued. <remarks>
         /// It should be set by the CLIENT after the token was received from the server.
         /// </remarks> 


### PR DESCRIPTION
As it's only one property at the json response it works just fine. I've testested it one API in production and it worked like a charm.