### PR TITLE
Netcore test improvements

### DIFF
--- a/Src/Support/GoogleApis.Auth.Tests_dotnetcore/project.json
+++ b/Src/Support/GoogleApis.Auth.Tests_dotnetcore/project.json
@@ -7,16 +7,16 @@
     "GoogleApis.Tests_dotnetcore": {
       "target": "project"
     },
-    "Nunit": "3.4.0",
-    "dotnet-test-nunit": "3.4.0-beta-1"
+    "Nunit": "3.4.1",
+    "dotnet-test-nunit": "3.4.0-beta-1",
+    "Moq": "4.6.36-alpha"
   },
 
   "buildOptions": {
     "compile": {
       "include": [ "../GoogleApis.Auth.Tests/**/*.cs" ],
       "exclude": [
-        "../GoogleApis.Auth.Tests/Program.cs",
-        "../GoogleApis.Auth.Tests/OAuth2/Flows/*.cs"
+        "../GoogleApis.Auth.Tests/Program.cs", // Uses NUnitLite
       ]
     }
   },

--- a/Src/Support/GoogleApis.Auth.Tests_dotnetcore/project.json
+++ b/Src/Support/GoogleApis.Auth.Tests_dotnetcore/project.json
@@ -11,26 +11,29 @@
     "dotnet-test-nunit": "3.4.0-beta-1"
   },
 
-  "compile": "../GoogleApis.Auth.Tests/**/*.cs",
-    
-  "exclude": [
-    "../GoogleApis.Auth.Tests/Program.cs",
-    "../GoogleApis.Auth.Tests/OAuth2/Flows/*.cs"
-  ],
+  "buildOptions": {
+    "compile": {
+      "include": [ "../GoogleApis.Auth.Tests/**/*.cs" ],
+      "exclude": [
+        "../GoogleApis.Auth.Tests/Program.cs",
+        "../GoogleApis.Auth.Tests/OAuth2/Flows/*.cs"
+      ]
+    }
+  },
 
   "testRunner": "nunit",
 
   "frameworks": {
     "netcoreapp1.0": {
       "imports": [
-	"netcoreapp1.0",
-	"portable-net45+win8"
+        "netcoreapp1.0",
+        "portable-net45+win8"
       ],
       "dependencies": {
-	"Microsoft.NETCore.App": {
-	  "version": "1.0.0-*",
-	  "type": "platform"
-	}
+        "Microsoft.NETCore.App": {
+          "version": "1.0.0-*",
+          "type": "platform"
+        }
       }
     }
   }

--- a/Src/Support/GoogleApis.Tests/Apis/Logging/NullLoggerTests.cs
+++ b/Src/Support/GoogleApis.Tests/Apis/Logging/NullLoggerTests.cs
@@ -15,9 +15,7 @@ limitations under the License.
 */
 
 using System;
-using System.IO;
 using Google.Apis.Logging;
-using Moq;
 using NUnit.Framework;
 
 namespace Google.Apis.Tests.Apis.Logging

--- a/Src/Support/GoogleApis.Tests/Apis/Requests/ClientServiceRequestTest.cs
+++ b/Src/Support/GoogleApis.Tests/Apis/Requests/ClientServiceRequestTest.cs
@@ -17,6 +17,7 @@ limitations under the License.
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -25,7 +26,6 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Ionic.Zlib;
 using NUnit.Framework;
 
 using Google.Apis.Discovery;

--- a/Src/Support/GoogleApis.Tests/Apis/Services/BaseClientServiceTest.cs
+++ b/Src/Support/GoogleApis.Tests/Apis/Services/BaseClientServiceTest.cs
@@ -97,7 +97,7 @@ namespace Google.Apis.Tests.Apis.Services
             Assert.IsInstanceOf<NewtonsoftJsonSerializer>(client.Serializer);
 
             // Check that the response is decoded correctly.
-            var stream = new MemoryStream(Encoding.Default.GetBytes(Response));
+            var stream = new MemoryStream(Encoding.UTF8.GetBytes(Response));
             var response = new HttpResponseMessage { Content = new StreamContent(stream) };
             CheckDeserializationResult(client.DeserializeResponse<MockJsonSchema>(response).Result);
         }
@@ -116,7 +116,7 @@ namespace Google.Apis.Tests.Apis.Services
             Assert.IsInstanceOf<NewtonsoftJsonSerializer>(client.Serializer);
 
             // Check that the response is decoded correctly
-            var stream = new MemoryStream(Encoding.Default.GetBytes(Response));
+            var stream = new MemoryStream(Encoding.UTF8.GetBytes(Response));
             var response = new HttpResponseMessage { Content = new StreamContent(stream) };
             CheckDeserializationResult(
                 client.DeserializeResponse<MockJsonSchema>(response).Result);
@@ -168,7 +168,7 @@ namespace Google.Apis.Tests.Apis.Services
             MockClientService client = new MockClientService();
 
             // Check that the response is decoded correctly
-            var stream = new MemoryStream(Encoding.Default.GetBytes(Response));
+            var stream = new MemoryStream(Encoding.UTF8.GetBytes(Response));
             var response = new HttpResponseMessage { Content = new StreamContent(stream) };
             string result = client.DeserializeResponse<string>(response).Result;
             Assert.AreEqual(Response, result);
@@ -198,7 +198,7 @@ namespace Google.Apis.Tests.Apis.Services
 
             var client = CreateClientService(features);
 
-            using (var stream = new MemoryStream(Encoding.Default.GetBytes(ErrorResponse)))
+            using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(ErrorResponse)))
             {
                 var response = new HttpResponseMessage { Content = new StreamContent(stream) };
                 RequestError error = client.DeserializeError(response).Result;

--- a/Src/Support/GoogleApis.Tests/GoogleApis.Tests.csproj
+++ b/Src/Support/GoogleApis.Tests/GoogleApis.Tests.csproj
@@ -77,10 +77,6 @@
       <HintPath>..\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Moq, Version=4.2.1402.2112, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
-      <HintPath>..\packages\Moq.4.2.1402.2112\lib\net40\Moq.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
@@ -100,10 +96,6 @@
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.WebRequest" />
-    <Reference Include="Zlib.Portable, Version=1.11.0.0, Culture=neutral, PublicKeyToken=431cba815f6a8b5b, processorArchitecture=MSIL">
-      <HintPath>..\packages\Zlib.Portable.Signed.1.11.0\lib\portable-net4+sl5+wp8+win8+wpa81+MonoTouch+MonoAndroid\Zlib.Portable.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Apis\Download\MediaDownloaderTest.cs" />

--- a/Src/Support/GoogleApis.Tests_dotnetcore/project.json
+++ b/Src/Support/GoogleApis.Tests_dotnetcore/project.json
@@ -3,35 +3,36 @@
 
   "dependencies": {
     "Google.Apis.Core": "1.14",
+    "Google.Apis": "1.14",
     "Nunit": "3.4.0",
     "dotnet-test-nunit": "3.4.0-beta-1"
   },
 
-  "compile": "../GoogleApis.Tests/**/*.cs",
-
-  "exclude": [
-    "../GoogleApis.Tests/Program.cs",
-    "../GoogleApis.Tests/Apis/*/*.cs",
-    "../GoogleApis.Tests/[Mock]/CountableMessageHandler.cs",
-    "../GoogleApis.Tests/[Mock]/MockBackOffHandler.cs",
-    "../GoogleApis.Tests/[Mock]/MockClientService.cs",
-    "../GoogleApis.Tests/[Mock]/MockHttpClientFactory.cs",
-    "../GoogleApis.Tests/[Mock]/MockMessageHandler.cs"
-  ],
+  "buildOptions": {
+    "compile": {
+      "include": [ "../GoogleApis.Tests/**/*.cs" ],
+      "exclude": [
+        "../GoogleApis.Tests/Program.cs",
+        "../GoogleApis.Tests/Apis/Download/*.cs", // Uses HttpListener
+        "../GoogleApis.Tests/Apis/Upload/*.cs", // Uses HttpListener
+        "../GoogleApis.Tests/Apis/Requests/BatchRequestTest.cs" // Needs access to internal methods
+      ]
+    }
+  },
 
   "testRunner": "nunit",
 
   "frameworks": {
     "netcoreapp1.0": {
       "imports": [
-	"netcoreapp1.0",
-	"portable-net45+win8"
+        "netcoreapp1.0",
+        "portable-net45+win8"
       ],
       "dependencies": {
-	"Microsoft.NETCore.App": {
-	  "version": "1.0.0-*",
-	  "type": "platform"
-	}
+        "Microsoft.NETCore.App": {
+          "version": "1.0.0-*",
+          "type": "platform"
+        }
       }
     }
   }

--- a/Src/Support/GoogleApis.Tests_dotnetcore/project.json
+++ b/Src/Support/GoogleApis.Tests_dotnetcore/project.json
@@ -12,7 +12,7 @@
     "compile": {
       "include": [ "../GoogleApis.Tests/**/*.cs" ],
       "exclude": [
-        "../GoogleApis.Tests/Program.cs",
+        "../GoogleApis.Tests/Program.cs", // Uses NUnitLite
         "../GoogleApis.Tests/Apis/Download/*.cs", // Uses HttpListener
         "../GoogleApis.Tests/Apis/Upload/*.cs", // Uses HttpListener
         "../GoogleApis.Tests/Apis/Requests/BatchRequestTest.cs" // Needs access to internal methods

--- a/run_tests_dotnetcore.bat
+++ b/run_tests_dotnetcore.bat
@@ -8,16 +8,14 @@ msbuild SupportLibraries.proj
 
 REM Clean slate after the build.
 set workspace=%~dp0
-set fallback=%workspace%\NuPkgs
-set packages=%workspace%\packages
+set nugetconfig=%workspace%\NuGet.Config
 
 REM Restore the test projects.
 dotnet restore ^
   "Src\Support\GoogleApis.Tests_dotnetcore" ^
   "Src\Support\GoogleApis.Auth.Tests_dotnetcore" ^
-  --packages "%packages%" ^
-  -f "%fallback%" ^
-  --no-cache
+  --no-cache ^
+  --configfile "%nugetconfig%"
 
 REM Run the tests.
 dotnet test "Src\Support\GoogleApis.Tests_dotnetcore"


### PR DESCRIPTION
Enable ~100 more GoogleApis.Tests test-cases in .NET core. Tidy up project.json's. Remove unneeded Moq & Ionic.ZLib dependencies from test project. Tidy up run_tests_dotnetcore.bat.