### PR TITLE
Remove ServiceAccountCredentials from netstandard

### DIFF
--- a/Src/Support/GoogleApis.Auth.NetStandard/project.json
+++ b/Src/Support/GoogleApis.Auth.NetStandard/project.json
@@ -13,10 +13,6 @@
     "System.Net.Http": "4.1.0",
     "System.Runtime": "4.1.0",
     "System.Runtime.Extensions": "4.1.0",
-    "System.Security.Cryptography.Algorithms": "4.2.0",
-    "System.Security.Cryptography.Csp": "4.0.0",
-    "System.Security.Cryptography.Primitives": "4.0.0",
-    "System.Security.Cryptography.X509Certificates": "4.1.0",
     "System.Text.Encoding": "4.0.11",
     "System.Threading.Tasks": "4.0.11"
   },

--- a/Src/Support/GoogleApis.Auth.PlatformServices_Shared/OAuth2/DefaultCredentialProvider.cs
+++ b/Src/Support/GoogleApis.Auth.PlatformServices_Shared/OAuth2/DefaultCredentialProvider.cs
@@ -182,11 +182,14 @@ namespace Google.Apis.Auth.OAuth2
             {
                 case JsonCredentialParameters.AuthorizedUserCredentialType:
                     return new GoogleCredential(CreateUserCredentialFromJson(credentialParameters));
-
+#if !NETSTANDARD
                 case JsonCredentialParameters.ServiceAccountCredentialType:
                     return GoogleCredential.FromCredential(
                         CreateServiceAccountCredentialFromJson(credentialParameters));
-                
+#else
+                case JsonCredentialParameters.ServiceAccountCredentialType:
+                    throw new InvalidOperationException("Service Account credentials are not supported in .NET Core.");
+#endif
                 default:
                     throw new InvalidOperationException(
                         String.Format("Error creating credential from JSON. Unrecognized credential type {0}.", 
@@ -221,6 +224,7 @@ namespace Google.Apis.Auth.OAuth2
             return new UserCredential(flow, "ApplicationDefaultCredentials", token);
         }
 
+#if !NETSTANDARD
         /// <summary>Creates a <see cref="ServiceAccountCredential"/> from JSON data.</summary>
         private static ServiceAccountCredential CreateServiceAccountCredentialFromJson(
             JsonCredentialParameters credentialParameters)
@@ -234,6 +238,7 @@ namespace Google.Apis.Auth.OAuth2
             var initializer = new ServiceAccountCredential.Initializer(credentialParameters.ClientEmail);
             return new ServiceAccountCredential(initializer.FromPrivateKey(credentialParameters.PrivateKey));
         }
+#endif
 
         /// <summary> 
         /// Returns platform-specific well known credential file path. This file is created by 

--- a/Src/Support/GoogleApis.Auth.PlatformServices_Shared/OAuth2/GoogleCredential.cs
+++ b/Src/Support/GoogleApis.Auth.PlatformServices_Shared/OAuth2/GoogleCredential.cs
@@ -169,7 +169,8 @@ namespace Google.Apis.Auth.OAuth2
         /// <summary>Provides access to the underlying credential object</summary>
         internal ICredential UnderlyingCredential { get { return credential; } }
 
-        #region Factory methods
+#if !NETSTANDARD
+#region Factory methods
 
         /// <summary>Creates a <c>GoogleCredential</c> wrapping a <see cref="ServiceAccountCredential"/>.</summary>
         internal static GoogleCredential FromCredential(ServiceAccountCredential credential)
@@ -177,7 +178,7 @@ namespace Google.Apis.Auth.OAuth2
             return new ServiceAccountGoogleCredential(credential);
         }
 
-        #endregion
+#endregion
 
         /// <summary>
         /// Wraps <c>ServiceAccountCredential</c> as <c>GoogleCredential</c>.
@@ -189,7 +190,7 @@ namespace Google.Apis.Auth.OAuth2
             public ServiceAccountGoogleCredential(ServiceAccountCredential credential)
                 : base(credential) { }
 
-            #region GoogleCredential overrides
+#region GoogleCredential overrides
 
             public override bool IsCreateScopedRequired
             {
@@ -208,7 +209,8 @@ namespace Google.Apis.Auth.OAuth2
                 return new ServiceAccountGoogleCredential(new ServiceAccountCredential(initializer));
             }
 
-            #endregion
+#endregion
         }
+#endif
     }
 }

--- a/Src/Support/GoogleApis.Auth.PlatformServices_Shared/OAuth2/ServiceAccountCredential.cs
+++ b/Src/Support/GoogleApis.Auth.PlatformServices_Shared/OAuth2/ServiceAccountCredential.cs
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#if !NETSTANDARD // RSACryptoServiceProvider is not supported on Linux. TODO: Use alternative
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -341,3 +343,4 @@ namespace Google.Apis.Auth.OAuth2
         }
     }
 }
+#endif

--- a/Src/Support/GoogleApis.Auth/Google.Apis.Auth.nuspec
+++ b/Src/Support/GoogleApis.Auth/Google.Apis.Auth.nuspec
@@ -53,10 +53,6 @@
           <dependency id="System.Net.Requests" version="4.0.11" />
           <dependency id="System.Runtime" version="4.1.0" />
           <dependency id="System.Runtime.Extensions" version="4.1.0" />
-          <dependency id="System.Security.Cryptography.Algorithms" version="4.2.0" />
-          <dependency id="System.Security.Cryptography.Csp" version="4.0.0" />
-          <dependency id="System.Security.Cryptography.Primitives" version="4.0.0" />
-          <dependency id="System.Security.Cryptography.X509Certificates" version="4.1.0" />
           <dependency id="System.Text.Encoding" version="4.0.11" />
           <dependency id="System.Threading" version="4.0.11" />
           <dependency id="System.Threading.Tasks" version="4.0.11" />

--- a/Src/Support/GoogleApis.Tests_dotnetcore/project.json
+++ b/Src/Support/GoogleApis.Tests_dotnetcore/project.json
@@ -17,6 +17,11 @@
         "**/*.cs",
         "../GoogleApis.Tests/**/*.cs",
       ],
+      "exclude": [
+        // Excluded until they don't cause a huge delay on CI
+        "../GoogleApis.Tests/Apis/Upload/**",
+        "../GoogleApis.Tests/Apis/Download/**"
+      ]
     },
     "define": [ "NETSTANDARD" ]
   },


### PR DESCRIPTION
Due to missing cryptography platform support.