### PR TITLE
NetStandard improvements

### DIFF
--- a/Src/Support/GoogleApis.Auth.DotNet4.Tests/GoogleApis.Auth.PlatformServices.Tests_Net45.csproj
+++ b/Src/Support/GoogleApis.Auth.DotNet4.Tests/GoogleApis.Auth.PlatformServices.Tests_Net45.csproj
@@ -49,6 +49,10 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="BouncyCastle.Crypto, Version=1.7.4137.9688, Culture=neutral, PublicKeyToken=a4292a325f69b123, processorArchitecture=MSIL">
+      <HintPath>..\packages\BouncyCastle.1.7.0\lib\Net40-Client\BouncyCastle.Crypto.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Moq, Version=4.2.1402.2112, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\packages\Moq.4.2.1402.2112\lib\net40\Moq.dll</HintPath>
       <Private>True</Private>
@@ -66,6 +70,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />
@@ -79,6 +84,7 @@
   <ItemGroup>
     <Compile Include="OAuth2\GoogleCredentialTests.cs" />
     <Compile Include="OAuth2\DefaultCredentialProviderTests.cs" />
+    <Compile Include="OAuth2\ServiceAccountCredentialTests.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="..\CommonAssemblyInfo.cs">
@@ -98,6 +104,10 @@
       <Project>{e83c6d98-c348-4944-ad7f-c4e428141079}</Project>
       <Name>GoogleApis.Core_Net45</Name>
     </ProjectReference>
+    <ProjectReference Include="..\GoogleApis.Tests\GoogleApis.Tests.csproj">
+      <Project>{9a8aa9ef-6904-43d8-8a26-0ab62069c2dc}</Project>
+      <Name>GoogleApis.Tests</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
@@ -106,6 +116,7 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Src/Support/GoogleApis.Auth.DotNet4.Tests/OAuth2/ServiceAccountCredentialTests.cs
+++ b/Src/Support/GoogleApis.Auth.DotNet4.Tests/OAuth2/ServiceAccountCredentialTests.cs
@@ -42,7 +42,7 @@ ZUp8AsbVqF6rbLiiUfJMo2btGclQu4DEVyS+ymFA65tXDLUuR9EDqJYdqHNZJ5B8
 ""client_id"": ""CLIENT_ID"",
 ""type"": ""service_account""}";
 
-        var credentialParameters = NewtonsoftJsonSerializer.Instance.Deserialize<JsonCredentialParameters>(dummyServiceAccountCredentialFileContents);
+            var credentialParameters = NewtonsoftJsonSerializer.Instance.Deserialize<JsonCredentialParameters>(dummyServiceAccountCredentialFileContents);
             var initializer = new ServiceAccountCredential.Initializer(credentialParameters.ClientEmail)
             {
                 Clock = new MockClock { UtcNow = new DateTime(2016, 1, 1, 0, 0, 0, DateTimeKind.Utc) }
@@ -62,7 +62,7 @@ ZUp8AsbVqF6rbLiiUfJMo2btGclQu4DEVyS+ymFA65tXDLUuR9EDqJYdqHNZJ5B8
             Assert.That(accessToken, Is.EqualTo(expectedToken));
         }
 
-#if !NETSTANDARD // ServiceAccountCredential not currently supported on netstandard.
+#if !NETSTANDARD // ServiceAccountCredential initialization from X509 cert not currently supported on netstandard.
         [Test]
         public async Task ValidLocallySignedAccessToken_FromX509Certificate()
         {

--- a/Src/Support/GoogleApis.Auth.DotNet4.Tests/OAuth2/ServiceAccountCredentialTests.cs
+++ b/Src/Support/GoogleApis.Auth.DotNet4.Tests/OAuth2/ServiceAccountCredentialTests.cs
@@ -1,0 +1,125 @@
+﻿using Google.Apis.Json;
+using Google.Apis.Tests;
+using NUnit.Framework;
+using Org.BouncyCastle.Crypto.Parameters;
+using Org.BouncyCastle.Security;
+using Org.BouncyCastle.Utilities.IO.Pem;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Google.Apis.Auth.OAuth2
+{
+    [TestFixture]
+    public class ServiceAccountCredentialTests
+    {
+
+        [Test]
+        public async Task ValidLocallySignedAccessToken_FromPrivateKey()
+        {
+            const string dummyServiceAccountCredentialFileContents = @"{
+""private_key_id"": ""PRIVATE_KEY_ID"",
+""private_key"": ""-----BEGIN PRIVATE KEY-----
+MIICdgIBADANBgkqhkiG9w0BAQEFAASCAmAwggJcAgEAAoGBAJJM6HT4s6btOsfe
+2x4zrzrwSUtmtR37XTTi0sPARTDF8uzmXy8UnE5RcVJzEH5T2Ssz/ylX4Sl/CI4L
+no1l8j9GiHJb49LSRjWe4Yx936q0Xj9H0R1HTxvjUPqwAsTwy2fKBTog+q1frqc9
+o8s2r6LYivUGDVbhuUzCaMJsf+x3AgMBAAECgYEAi0FTXsu/zRswAUGaViQiHjrL
+uU65BSHXNVjV/2fLNEKnGWGqpli68z1IXY+S2nwbUak7rnGsq9/0F6jtsW+hZbLk
+KXUOuuExpeC5Kd6ngWX/f2jqmhlUabiQijU9cVk7pMq8EHkRtvlosnMTUAEzempu
+QUPwn1PZHhmJkBvZ4lECQQDCErrxl+e3BwUDcS0yVEEmCNSG6xdXs2878b8rzbe7
+3Mmi6SuuOLi3PU92J+j+f/MOdtYrk13mEDdYmd5dhrt5AkEAwPvDEsDT/W4y4h5n
+gv1awGBA5aLFE1JNWM/Gwn4D1cGpEDHKFREaBtxMDCASpHJuw8r7zUywpKhmBZcf
+GS37bwJANdSAKfbafLfjuhqwUJ9yGpykZm/a36aTmerp/bpn1iHdg+RtCzwMcDb/
+TWSwibbvsflgWmHbz657y4WSWhq+8QJAWrpCNN/ZCk2zuGDo80lfUBAwkoVat8G6
+wWU1oZyS+vzIGef+hLb8kHsjeZPej9eIwZ39kcBbT54oELrCkRjwGwJAQ8V2A7lT
+ZUp8AsbVqF6rbLiiUfJMo2btGclQu4DEVyS+ymFA65tXDLUuR9EDqJYdqHNZJ5B8
+4Z5p2prkjWTLcA==
+-----END PRIVATE KEY-----"",
+""client_email"": ""CLIENT_EMAIL"",
+""client_id"": ""CLIENT_ID"",
+""type"": ""service_account""}";
+
+        var credentialParameters = NewtonsoftJsonSerializer.Instance.Deserialize<JsonCredentialParameters>(dummyServiceAccountCredentialFileContents);
+            var initializer = new ServiceAccountCredential.Initializer(credentialParameters.ClientEmail)
+            {
+                Clock = new MockClock { UtcNow = new DateTime(2016, 1, 1, 0, 0, 0, DateTimeKind.Utc) }
+            };
+            var cred = new ServiceAccountCredential(initializer.FromPrivateKey(credentialParameters.PrivateKey));
+
+            Assert.That(cred.Scopes?.Any(), Is.False); // HasScopes must be false for the type of access token we want to test.
+
+            string accessToken = await cred.GetAccessTokenForRequestAsync("http://authurl/");
+
+            string expectedToken =
+                "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJDTElFTlRfRU1BSUwiLCJz" +
+                "dWIiOiJDTElFTlRfRU1BSUwiLCJhdWQiOiJodHRwOi8vYXV0aHVybC8iLCJleHAiOjE0N" +
+                "TE2MTAwMDAsImlhdCI6MTQ1MTYwNjQwMH0.WLljSaAqxMVZnAxFA2SvpA3n2WRlQW71Nb" +
+                "CUkbN-ZI-EWoL-HhgiV_3ISrXMvbDHYhBR0vvtXE0PcRcsMEf51Y0jV4DXZ8hf-QJFq7O" +
+                "Hrepwe93dnDE6uNVnbj41_0phuy1WKwae29Qp2aPI2Y8E8Z2tXQlF87E_MdgjXVeTF8k";
+            Assert.That(accessToken, Is.EqualTo(expectedToken));
+        }
+
+#if !NETSTANDARD // ServiceAccountCredential not currently supported on netstandard.
+        [Test]
+        public async Task ValidLocallySignedAccessToken_FromX509Certificate()
+        {
+            const string sPrivateKey = @"
+MIICdgIBADANBgkqhkiG9w0BAQEFAASCAmAwggJcAgEAAoGBALQoMIfUT93VMvb5
+4U5dsJLXD1D6z4o/VuVlNUaf5xH01qAv8Egpxe6f5frLB/p1eNyDjNIZ3QitD6aN
+9Vfh4ifg6txBuBJtIMfSDvRJITNZ2SjKJREbflZuBk0HINKYQk2H+3TIzUbE/pN4
+Cu6Mids5L/oVOnRWIe3bEC+PHR7ZAgMBAAECgYBI1qrwb+2ukeFeK59lcMnQRLVD
+l3RLv9ohOy80E7h38RbJgzhR5NnK5ck1AduC7vXjqihIVf6g4F+ghmq4knI94KPQ
+2fOyQGVV6jVeRVqMusx7tP9V1H26yABiK6TPklcCsWwADFmexfOxfIgbBGSmlbAd
+N2/ad1Xog1xDebrbEQJBAO+2qSIDX1ahfxUyvvcMaix6Mrh/OYKb5aH1Y/7MfAav
+lpbQavQHNvak2147aPNxy0ZvWdJ2HVA7hUMkgysYWSUCQQDAZalkZMSrve+Onh55
+U+w5xjLklhh8PhYxx8plT8ae9VG75dGvWSz/W81B3ILg2lrNU6o08NKBJdZsJYmc
+BeKlAkBtJh3zF9gEaTqlW1rqwKNjpyyLJ5r3JqczzLmAXnmmzbLi7vmULejP+5bL
+XH/YQZtOcgtTMmb8jm2Kegijyc1lAkANGt+e5v4+dIGMxVhuCzlb9hQhXdftHo2E
+dodivzxYN32Jvu25c+mMu0QP6GVBy53Dvp8pW/36rgkc9LGa3wvBAkEA7dGAl95T
+UeNFVfuzkYNtQppcSgrx1oTcpTHoNgcvk8AgBf4yDdJJyo0IUONmgJCVffc1aTWn
+nf/8cW9YC+0icQ==";
+            const string sCert = @"
+MIICNDCCAZ2gAwIBAgIJAKl3qU1+NsuuMA0GCSqGSIb3DQEBCwUAMDMxCzAJBgNV
+BAYTAkdCMRMwEQYDVQQIDApTb21lLVN0YXRlMQ8wDQYDVQQKDAZHb29nbGUwHhcN
+MTYwODEwMTQwOTQ2WhcNNDMxMjI3MTQwOTQ2WjAzMQswCQYDVQQGEwJHQjETMBEG
+A1UECAwKU29tZS1TdGF0ZTEPMA0GA1UECgwGR29vZ2xlMIGfMA0GCSqGSIb3DQEB
+AQUAA4GNADCBiQKBgQC0KDCH1E/d1TL2+eFOXbCS1w9Q+s+KP1blZTVGn+cR9Nag
+L/BIKcXun+X6ywf6dXjcg4zSGd0IrQ+mjfVX4eIn4OrcQbgSbSDH0g70SSEzWdko
+yiURG35WbgZNByDSmEJNh/t0yM1GxP6TeArujInbOS/6FTp0ViHt2xAvjx0e2QID
+AQABo1AwTjAdBgNVHQ4EFgQUMqzJi099PA8ML5CV1OSiHgiTGoUwHwYDVR0jBBgw
+FoAUMqzJi099PA8ML5CV1OSiHgiTGoUwDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0B
+AQsFAAOBgQBQ9cMInb2rEcg8TTYq8MjDEegHWLUI9Dq/IvP/FHyKDczza4eX8m+G
+3buutN74pX2/GHRgqvqEvvUUuAQUnZ36k6KjTNxfzNLiSXDPNeYmy6PWsUZy4Rye
+/Van/ePiXdipTKMiUyl7V6dTjkE5p/e372wNVXUpcxOMmYdWmzSMvg==";
+
+            var privateParams = (RsaPrivateCrtKeyParameters)PrivateKeyFactory.CreateKey(Convert.FromBase64String(sPrivateKey));
+            var x509Cert = new X509Certificate2(Convert.FromBase64String(sCert));
+            var rsaParameters = DotNetUtilities.ToRSAParameters(privateParams);
+            var privateKey = new System.Security.Cryptography.RSACryptoServiceProvider();
+            privateKey.ImportParameters(rsaParameters);
+            x509Cert.PrivateKey = privateKey;
+
+            var initializer = new ServiceAccountCredential.Initializer("some-id")
+            {
+                Clock = new MockClock { UtcNow = new DateTime(2016, 1, 1, 0, 0, 0, DateTimeKind.Utc) }
+            };
+            var cred = new ServiceAccountCredential(initializer.FromCertificate(x509Cert));
+
+            Assert.That(cred.Scopes?.Any(), Is.False); // HasScopes must be false for the type of access token we want to test.
+
+            string accessToken = await cred.GetAccessTokenForRequestAsync("http://authurl/");
+
+            string expectedToken =
+                "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzb21lLWlkIiwic3ViIjoi" +
+                "c29tZS1pZCIsImF1ZCI6Imh0dHA6Ly9hdXRodXJsLyIsImV4cCI6MTQ1MTYxMDAwMCwia" +
+                "WF0IjoxNDUxNjA2NDAwfQ.GfpDHgrFi4ZlGC5LuJEarLU4_eTrT5PVa-S40YtkdB2E1f3" +
+                "4naYG2ItcfBEFg7Gbdkr1cIAyipuhEd2yLfPmWGwhOwVcBRNyK_J5w8RodS44mxNJwau0" +
+                "jKy4x1K20ybLqcnNgzE0wag6fi5GHwdNIB0URdHDTiC88CRYdl1CIdk";
+            Assert.That(accessToken, Is.EqualTo(expectedToken));
+        }
+#endif
+    }
+}

--- a/Src/Support/GoogleApis.Auth.DotNet4.Tests/Program.cs
+++ b/Src/Support/GoogleApis.Auth.DotNet4.Tests/Program.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+#if !NETSTANDARD
 using NUnitLite;
 
 namespace NUnitLite.Tests
@@ -39,3 +40,4 @@ namespace NUnitLite.Tests
         }
     }
 }
+#endif

--- a/Src/Support/GoogleApis.Auth.DotNet4.Tests/packages.config
+++ b/Src/Support/GoogleApis.Auth.DotNet4.Tests/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="BouncyCastle" version="1.7.0" targetFramework="net45" />
   <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="NUnit" version="3.2.1" targetFramework="net45" />

--- a/Src/Support/GoogleApis.Auth.NetStandard/GoogleApis.Auth.PlatformServices_NetStandard.csproj
+++ b/Src/Support/GoogleApis.Auth.NetStandard/GoogleApis.Auth.PlatformServices_NetStandard.csproj
@@ -56,6 +56,7 @@
     <Compile Include="..\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="OAuth2\RsaStandard.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
@@ -68,7 +69,6 @@
       <Name>GoogleApis.Core_NetStandard</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup />
   <Import Project="..\GoogleApis.Auth.PlatformServices_Shared\GoogleApis.Auth.PlatformServices_Shared.projitems" Label="Shared" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Src/Support/GoogleApis.Auth.NetStandard/OAuth2/RsaStandard.cs
+++ b/Src/Support/GoogleApis.Auth.NetStandard/OAuth2/RsaStandard.cs
@@ -1,0 +1,77 @@
+﻿using Org.BouncyCastle.Asn1.Nist;
+using Org.BouncyCastle.Crypto.Digests;
+using Org.BouncyCastle.Crypto.Parameters;
+using Org.BouncyCastle.Crypto.Signers;
+using System;
+using System.IO;
+using System.Security.Cryptography;
+
+namespace Google.Apis.Auth.OAuth2
+{
+    /// <summary>
+    /// An implementation of RSA, just sufficient for the needs of ServiceAccountCredential.
+    /// This is not a general-purpose implementation of RSA.
+    /// </summary>
+    internal class RsaStandard : RSA
+    {
+        public RsaStandard(RsaPrivateCrtKeyParameters parameters)
+        {
+            _parameters = parameters;
+        }
+
+        private RsaPrivateCrtKeyParameters _parameters;
+
+        public override byte[] Decrypt(byte[] data, RSAEncryptionPadding padding)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override byte[] Encrypt(byte[] data, RSAEncryptionPadding padding)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override RSAParameters ExportParameters(bool includePrivateParameters)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void ImportParameters(RSAParameters parameters)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override byte[] SignHash(byte[] hash, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding)
+        {
+            if (hashAlgorithm != HashAlgorithmName.SHA256)
+            {
+                throw new ArgumentException(
+                    $"Unsupported HashAlgorithmName '{hashAlgorithm}', only SHA256 supported.", nameof(hashAlgorithm));
+            }
+            if (padding != RSASignaturePadding.Pkcs1)
+            {
+                throw new ArgumentException(
+                    $"Unsupported RSASignaturePadding '{padding}', only Pkcs1 supported.", nameof(padding));
+            }
+            var signer = new RsaDigestSigner(new NullDigest(), NistObjectIdentifiers.IdSha256);
+            signer.Init(true, _parameters);
+            signer.BlockUpdate(hash, 0, hash.Length);
+            return signer.GenerateSignature();
+        }
+
+        public override bool VerifyHash(byte[] hash, byte[] signature, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding)
+        {
+            throw new NotImplementedException();
+        }
+
+        protected override byte[] HashData(Stream data, HashAlgorithmName hashAlgorithm)
+        {
+            throw new NotImplementedException();
+        }
+
+        protected override byte[] HashData(byte[] data, int offset, int count, HashAlgorithmName hashAlgorithm)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Src/Support/GoogleApis.Auth.NetStandard/OAuth2/RsaStandard.cs
+++ b/Src/Support/GoogleApis.Auth.NetStandard/OAuth2/RsaStandard.cs
@@ -14,12 +14,12 @@ namespace Google.Apis.Auth.OAuth2
     /// </summary>
     internal class RsaStandard : RSA
     {
+        private readonly RsaPrivateCrtKeyParameters _parameters;
+
         public RsaStandard(RsaPrivateCrtKeyParameters parameters)
         {
             _parameters = parameters;
         }
-
-        private RsaPrivateCrtKeyParameters _parameters;
 
         public override byte[] Decrypt(byte[] data, RSAEncryptionPadding padding)
         {

--- a/Src/Support/GoogleApis.Auth.NetStandard/Properties/AssemblyInfo.cs
+++ b/Src/Support/GoogleApis.Auth.NetStandard/Properties/AssemblyInfo.cs
@@ -15,5 +15,17 @@ limitations under the License.
 */
 
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
 [assembly: AssemblyTitle("Google.Apis.Auth.PlatformServices")]
+
+#if SIGNED
+[assembly: InternalsVisibleTo("GoogleApis.Auth.Tests_dotnetcore,PublicKey=" +
+    "00240000048000009400000006020000002400005253413100040000010001003d69fa08add2ea" +
+    "7341cc102edb2f3a59bb49e7f7c8bf1bd96d494013c194f4d80ee30278f20e08a0b7cb863d6522" +
+    "d8c1c0071dd36748297deefeb99e899e6a80b9ddc490e88ea566d2f7d4f442211f7beb6b2387fb" +
+    "435bfaa3ecfe7afc0184cc46f80a5866e6bb8eb73f64a3964ed82f6a5036b91b1ac93e1f44508b" +
+    "65e51fce")]
+#else
+[assembly: InternalsVisibleTo("GoogleApis.Auth.Tests_dotnetcore")]
+#endif

--- a/Src/Support/GoogleApis.Auth.PlatformServices_Shared/OAuth2/DefaultCredentialProvider.cs
+++ b/Src/Support/GoogleApis.Auth.PlatformServices_Shared/OAuth2/DefaultCredentialProvider.cs
@@ -182,14 +182,9 @@ namespace Google.Apis.Auth.OAuth2
             {
                 case JsonCredentialParameters.AuthorizedUserCredentialType:
                     return new GoogleCredential(CreateUserCredentialFromJson(credentialParameters));
-#if !NETSTANDARD
                 case JsonCredentialParameters.ServiceAccountCredentialType:
                     return GoogleCredential.FromCredential(
                         CreateServiceAccountCredentialFromJson(credentialParameters));
-#else
-                case JsonCredentialParameters.ServiceAccountCredentialType:
-                    throw new InvalidOperationException("Service Account credentials are not supported in .NET Core.");
-#endif
                 default:
                     throw new InvalidOperationException(
                         String.Format("Error creating credential from JSON. Unrecognized credential type {0}.", 
@@ -224,7 +219,6 @@ namespace Google.Apis.Auth.OAuth2
             return new UserCredential(flow, "ApplicationDefaultCredentials", token);
         }
 
-#if !NETSTANDARD
         /// <summary>Creates a <see cref="ServiceAccountCredential"/> from JSON data.</summary>
         private static ServiceAccountCredential CreateServiceAccountCredentialFromJson(
             JsonCredentialParameters credentialParameters)
@@ -238,7 +232,6 @@ namespace Google.Apis.Auth.OAuth2
             var initializer = new ServiceAccountCredential.Initializer(credentialParameters.ClientEmail);
             return new ServiceAccountCredential(initializer.FromPrivateKey(credentialParameters.PrivateKey));
         }
-#endif
 
         /// <summary> 
         /// Returns platform-specific well known credential file path. This file is created by 

--- a/Src/Support/GoogleApis.Auth.PlatformServices_Shared/OAuth2/GoogleCredential.cs
+++ b/Src/Support/GoogleApis.Auth.PlatformServices_Shared/OAuth2/GoogleCredential.cs
@@ -148,37 +148,24 @@ namespace Google.Apis.Auth.OAuth2
             return CreateScoped((IEnumerable<string>) scopes);
         }
 
-        #region IConfigurableHttpClientInitializer
-
         void IConfigurableHttpClientInitializer.Initialize(ConfigurableHttpClient httpClient)
         {
             credential.Initialize(httpClient);
         }
-
-        #endregion
-
-        #region ITokenAccess
 
         Task<string> ITokenAccess.GetAccessTokenForRequestAsync(string authUri, CancellationToken cancellationToken)
         {
             return credential.GetAccessTokenForRequestAsync(authUri, cancellationToken);
         }
 
-        #endregion
-
         /// <summary>Provides access to the underlying credential object</summary>
         internal ICredential UnderlyingCredential { get { return credential; } }
-
-#if !NETSTANDARD
-#region Factory methods
 
         /// <summary>Creates a <c>GoogleCredential</c> wrapping a <see cref="ServiceAccountCredential"/>.</summary>
         internal static GoogleCredential FromCredential(ServiceAccountCredential credential)
         {
             return new ServiceAccountGoogleCredential(credential);
         }
-
-#endregion
 
         /// <summary>
         /// Wraps <c>ServiceAccountCredential</c> as <c>GoogleCredential</c>.
@@ -189,8 +176,6 @@ namespace Google.Apis.Auth.OAuth2
         {
             public ServiceAccountGoogleCredential(ServiceAccountCredential credential)
                 : base(credential) { }
-
-#region GoogleCredential overrides
 
             public override bool IsCreateScopedRequired
             {
@@ -208,9 +193,6 @@ namespace Google.Apis.Auth.OAuth2
                 };
                 return new ServiceAccountGoogleCredential(new ServiceAccountCredential(initializer));
             }
-
-#endregion
         }
-#endif
     }
 }

--- a/Src/Support/GoogleApis.Auth.PlatformServices_Shared/OAuth2/ServiceAccountCredential.cs
+++ b/Src/Support/GoogleApis.Auth.PlatformServices_Shared/OAuth2/ServiceAccountCredential.cs
@@ -58,6 +58,7 @@ namespace Google.Apis.Auth.OAuth2
     /// </summary>
     public class ServiceAccountCredential : ServiceCredential
     {
+        private const string Sha256Oig = "2.16.840.1.101.3.4.2.1";
         /// <summary>An initializer class for the service account credential. </summary>
         new public class Initializer : ServiceCredential.Initializer
         {
@@ -244,7 +245,7 @@ namespace Google.Apis.Auth.OAuth2
 #if NETSTANDARD
             var sigBytes = key.SignHash(assertionHash, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
 #else
-            var sigBytes = key.SignHash(assertionHash, "2.16.840.1.101.3.4.2.1" /* SHA256 OIG */);
+            var sigBytes = key.SignHash(assertionHash, Sha256Oig);
 #endif
             var signature = UrlSafeBase64Encode(sigBytes);
             assertion.Append(".").Append(signature);

--- a/Src/Support/GoogleApis.Auth.PlatformServices_Shared/OAuth2/ServiceAccountCredential.cs
+++ b/Src/Support/GoogleApis.Auth.PlatformServices_Shared/OAuth2/ServiceAccountCredential.cs
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#if !NETSTANDARD // RSACryptoServiceProvider is not supported on Linux. TODO: Use alternative
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -32,6 +30,12 @@ using Google.Apis.Auth.OAuth2.Requests;
 using Google.Apis.Json;
 using Google.Apis.Util;
 using Org.BouncyCastle.Math;
+
+#if NETSTANDARD
+using RsaKey = System.Security.Cryptography.RSA;
+#else
+using RsaKey = System.Security.Cryptography.RSACryptoServiceProvider;
+#endif
 
 namespace Google.Apis.Auth.OAuth2
 {
@@ -73,7 +77,7 @@ namespace Google.Apis.Auth.OAuth2
             /// Gets or sets the key which is used to sign the request, as specified in
             /// https://developers.google.com/accounts/docs/OAuth2ServiceAccount#computingsignature.
             /// </summary>
-            public RSACryptoServiceProvider Key { get; set; }
+            public RsaKey Key { get; set; }
 
             /// <summary>Constructs a new initializer using the given id.</summary>
             public Initializer(string id)
@@ -89,39 +93,33 @@ namespace Google.Apis.Auth.OAuth2
             /// <summary>Extracts the <see cref="Key"/> from the given PKCS8 private key.</summary>
             public Initializer FromPrivateKey(string privateKey)
             {
+#if NETSTANDARD
+                RsaPrivateCrtKeyParameters parameters = ConvertPKCS8ToRsaPrivateCrtKeyParameters(privateKey);
+                Key = new RsaStandard(parameters);
+#else
                 RSAParameters rsaParameters = ConvertPKCS8ToRSAParameters(privateKey);
                 Key = new RSACryptoServiceProvider();
                 Key.ImportParameters(rsaParameters);
+#endif
                 return this;
             }
 
+#if !NETSTANDARD // ServiceACcountCredential initialization from X509 cert not currently supported.
             /// <summary>Extracts a <see cref="Key"/> from the given certificate.</summary>
             public Initializer FromCertificate(X509Certificate2 certificate)
             {
-#if NETSTANDARD
-                RSA rsa = certificate.GetRSAPrivateKey();
-                RSAParameters rsaParameters = rsa.ExportParameters(true);
-                Key = new RSACryptoServiceProvider();
-                Key.ImportParameters(rsaParameters);
-#else
                 // Workaround to correctly cast the private key as a RSACryptoServiceProvider type 24.
                 RSACryptoServiceProvider rsa = (RSACryptoServiceProvider)certificate.PrivateKey;
                 byte[] privateKeyBlob = rsa.ExportCspBlob(true);
                 Key = new RSACryptoServiceProvider();
                 Key.ImportCspBlob(privateKeyBlob);
-#endif
                 return this;
             }
+#endif
         }
-
-#region Constants
 
         private const string PrivateKeyPrefix = "-----BEGIN PRIVATE KEY-----";
         private const string PrivateKeySuffix = "-----END PRIVATE KEY-----";
-
-#endregion
-
-#region Readonly fields
 
         /// <summary>Unix epoch as a <c>DateTime</c></summary>
         protected static readonly DateTime UnixEpoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
@@ -129,9 +127,7 @@ namespace Google.Apis.Auth.OAuth2
         private readonly string id;
         private readonly string user;
         private readonly IEnumerable<string> scopes;
-        private readonly RSACryptoServiceProvider key;
-
-#endregion
+        private readonly RsaKey key;
 
         /// <summary>Gets the service account ID (typically an e-mail address).</summary>
         public string Id { get { return id; } }
@@ -149,7 +145,7 @@ namespace Google.Apis.Auth.OAuth2
         /// Gets the key which is used to sign the request, as specified in
         /// https://developers.google.com/accounts/docs/OAuth2ServiceAccount#computingsignature.
         /// </summary>
-        public RSACryptoServiceProvider Key { get { return key; } }
+        public RsaKey Key { get { return key; } }
 
         /// <summary><c>true</c> if this credential has any scopes associated with it.</summary>
         internal bool HasScopes { get { return scopes != null && scopes.Any(); } }
@@ -162,8 +158,6 @@ namespace Google.Apis.Auth.OAuth2
             scopes = initializer.Scopes;
             key = initializer.Key.ThrowIfNull("initializer.Key");
         }
-
-#region ServiceCredential overrides
 
         /// <summary>
         /// Requests a new token as specified in 
@@ -192,7 +186,7 @@ namespace Google.Apis.Auth.OAuth2
         /// If <paramref name="authUri"/> is set and this credential has no scopes associated
         /// with it, a locally signed JWT access token for given <paramref name="authUri"/>
         /// is returned. Otherwise, an OAuth2 access token obtained from token server will be returned.
-        /// A cached token is used if possible and the token is only refreshed once its close to its expiry.
+        /// A cached token is used if possible and the token is only refreshed once it's close to its expiry.
         /// </summary>
         /// <param name="authUri">The URI the returned token will grant access to.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
@@ -208,8 +202,6 @@ namespace Google.Apis.Auth.OAuth2
             }
             return await base.GetAccessTokenForRequestAsync(authUri, cancellationToken).ConfigureAwait(false);
         }
-
-#endregion
     
         /// <summary>
         /// Creates a JWT access token than can be used in request headers instead of an OAuth2 token.
@@ -249,8 +241,12 @@ namespace Google.Apis.Auth.OAuth2
             // Sign the header and the payload.
             var hashAlg = SHA256.Create();
             byte[] assertionHash = hashAlg.ComputeHash(Encoding.ASCII.GetBytes(assertion.ToString()));
-
-            var signature = UrlSafeBase64Encode(key.SignHash(assertionHash, "2.16.840.1.101.3.4.2.1" /* SHA256 OIG */)); 
+#if NETSTANDARD
+            var sigBytes = key.SignHash(assertionHash, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+#else
+            var sigBytes = key.SignHash(assertionHash, "2.16.840.1.101.3.4.2.1" /* SHA256 OIG */);
+#endif
+            var signature = UrlSafeBase64Encode(sigBytes);
             assertion.Append(".").Append(signature);
             return assertion.ToString();
         }
@@ -273,14 +269,22 @@ namespace Google.Apis.Auth.OAuth2
         /// <summary>
         /// Converts the PKCS8 private key to RSA parameters. This method uses the Bouncy Castle library.
         /// </summary>
-        private static RSAParameters ConvertPKCS8ToRSAParameters(string pkcs8PrivateKey)
+        private static RsaPrivateCrtKeyParameters ConvertPKCS8ToRsaPrivateCrtKeyParameters(string pkcs8PrivateKey)
         {
             Utilities.ThrowIfNullOrEmpty(pkcs8PrivateKey, "pkcs8PrivateKey");
             var base64PrivateKey = pkcs8PrivateKey.Replace(PrivateKeyPrefix, "").Replace("\n", "")
                 .Replace(PrivateKeySuffix, "");
             var privateKeyBytes = Convert.FromBase64String(base64PrivateKey);
-            RsaPrivateCrtKeyParameters crtParameters =
-                (RsaPrivateCrtKeyParameters)PrivateKeyFactory.CreateKey(privateKeyBytes);
+            return (RsaPrivateCrtKeyParameters)PrivateKeyFactory.CreateKey(privateKeyBytes);
+        }
+
+        /// <summary>
+        /// Converts the PKCS8 private key to RSA parameters. This method uses the Bouncy Castle library.
+        /// </summary>
+        private static RSAParameters ConvertPKCS8ToRSAParameters(string pkcs8PrivateKey)
+        {
+            Utilities.ThrowIfNullOrEmpty(pkcs8PrivateKey, "pkcs8PrivateKey");
+            RsaPrivateCrtKeyParameters crtParameters = ConvertPKCS8ToRsaPrivateCrtKeyParameters(pkcs8PrivateKey);
             var rp = new RSAParameters();
             rp.Modulus = crtParameters.Modulus.ToByteArrayUnsigned();
             rp.Exponent = crtParameters.PublicExponent.ToByteArrayUnsigned();
@@ -343,4 +347,3 @@ namespace Google.Apis.Auth.OAuth2
         }
     }
 }
-#endif

--- a/Src/Support/GoogleApis.Auth.Tests/GoogleApis.Auth.Tests.csproj
+++ b/Src/Support/GoogleApis.Auth.Tests/GoogleApis.Auth.Tests.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -49,6 +49,10 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="BouncyCastle.Crypto, Version=1.7.4137.9688, Culture=neutral, PublicKeyToken=a4292a325f69b123, processorArchitecture=MSIL">
+      <HintPath>..\packages\BouncyCastle.1.7.0\lib\Net40-Client\BouncyCastle.Crypto.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Moq, Version=4.2.1402.2112, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\packages\Moq.4.2.1402.2112\lib\net40\Moq.dll</HintPath>
       <Private>True</Private>
@@ -87,6 +91,7 @@
     <Compile Include="OAuth2\Requests\RefreshTokenRequestTests.cs" />
     <Compile Include="OAuth2\Responses\AuthorizationCodeResponseUrlTests.cs" />
     <Compile Include="OAuth2\Responses\TokenResponseTests.cs" />
+    <Compile Include="OAuth2\RsaTests.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="..\CommonAssemblyInfo.cs">

--- a/Src/Support/GoogleApis.Auth.Tests/OAuth2/RsaTests.cs
+++ b/Src/Support/GoogleApis.Auth.Tests/OAuth2/RsaTests.cs
@@ -57,8 +57,6 @@ ZUp8AsbVqF6rbLiiUfJMo2btGclQu4DEVyS+ymFA65tXDLUuR9EDqJYdqHNZJ5B8
 #else
             var signature = rsa.SignHash(hash, "2.16.840.1.101.3.4.2.1" /* SHA256 OIG */);
 #endif
-            //var s = signature.Select(x => "0x" + x.ToString("x2")).Aggregate((a, b) => $"{a}, {b}");
-            //System.IO.File.WriteAllText(@"C:\Users\chrisbacon\zz.txt", s);
             var expected = new byte[]
             {
                 0x5d, 0xfc, 0x98, 0x59, 0x94, 0x64, 0x8c, 0x18, 0x54, 0x88, 0x8d, 0x65, 0xf3, 0xae, 0xdf, 0x76,

--- a/Src/Support/GoogleApis.Auth.Tests/OAuth2/RsaTests.cs
+++ b/Src/Support/GoogleApis.Auth.Tests/OAuth2/RsaTests.cs
@@ -1,0 +1,76 @@
+﻿using NUnit.Framework;
+using Org.BouncyCastle.Crypto.Parameters;
+using Org.BouncyCastle.Security;
+using System;
+using System.Security.Cryptography;
+
+#if NETSTANDARD
+using Rsa = System.Security.Cryptography.RSA;
+#else
+using Rsa = System.Security.Cryptography.RSACryptoServiceProvider;
+#endif
+
+namespace Google.Apis.Auth.OAuth2
+{
+    // This test is executed in NET45 and NETCore.
+    // Together they confirm that the RsaStandard RSA implementation is correct.
+    [TestFixture]
+    public class RsaTests
+    {
+        private static readonly string base64PrivateKey =
+@"MIICdgIBADANBgkqhkiG9w0BAQEFAASCAmAwggJcAgEAAoGBAJJM6HT4s6btOsfe
+2x4zrzrwSUtmtR37XTTi0sPARTDF8uzmXy8UnE5RcVJzEH5T2Ssz/ylX4Sl/CI4L
+no1l8j9GiHJb49LSRjWe4Yx936q0Xj9H0R1HTxvjUPqwAsTwy2fKBTog+q1frqc9
+o8s2r6LYivUGDVbhuUzCaMJsf+x3AgMBAAECgYEAi0FTXsu/zRswAUGaViQiHjrL
+uU65BSHXNVjV/2fLNEKnGWGqpli68z1IXY+S2nwbUak7rnGsq9/0F6jtsW+hZbLk
+KXUOuuExpeC5Kd6ngWX/f2jqmhlUabiQijU9cVk7pMq8EHkRtvlosnMTUAEzempu
+QUPwn1PZHhmJkBvZ4lECQQDCErrxl+e3BwUDcS0yVEEmCNSG6xdXs2878b8rzbe7
+3Mmi6SuuOLi3PU92J+j+f/MOdtYrk13mEDdYmd5dhrt5AkEAwPvDEsDT/W4y4h5n
+gv1awGBA5aLFE1JNWM/Gwn4D1cGpEDHKFREaBtxMDCASpHJuw8r7zUywpKhmBZcf
+GS37bwJANdSAKfbafLfjuhqwUJ9yGpykZm/a36aTmerp/bpn1iHdg+RtCzwMcDb/
+TWSwibbvsflgWmHbz657y4WSWhq+8QJAWrpCNN/ZCk2zuGDo80lfUBAwkoVat8G6
+wWU1oZyS+vzIGef+hLb8kHsjeZPej9eIwZ39kcBbT54oELrCkRjwGwJAQ8V2A7lT
+ZUp8AsbVqF6rbLiiUfJMo2btGclQu4DEVyS+ymFA65tXDLUuR9EDqJYdqHNZJ5B8
+4Z5p2prkjWTLcA==";
+
+        private Rsa GetRsa()
+        {
+            var privateKeyBytes = Convert.FromBase64String(base64PrivateKey);
+            var parameters = (RsaPrivateCrtKeyParameters)PrivateKeyFactory.CreateKey(privateKeyBytes);
+#if NETSTANDARD
+            return new RsaStandard(parameters);
+#else
+            var rsaCsp = new RSACryptoServiceProvider();
+            rsaCsp.ImportParameters(DotNetUtilities.ToRSAParameters(parameters));
+            return rsaCsp;
+#endif
+        }
+
+        [Test]
+        public void SignHash()
+        {
+            Rsa rsa = GetRsa();
+            var hash = new byte[32];
+            hash[0] = 45;
+#if NETSTANDARD
+            var signature = rsa.SignHash(hash, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+#else
+            var signature = rsa.SignHash(hash, "2.16.840.1.101.3.4.2.1" /* SHA256 OIG */);
+#endif
+            //var s = signature.Select(x => "0x" + x.ToString("x2")).Aggregate((a, b) => $"{a}, {b}");
+            //System.IO.File.WriteAllText(@"C:\Users\chrisbacon\zz.txt", s);
+            var expected = new byte[]
+            {
+                0x5d, 0xfc, 0x98, 0x59, 0x94, 0x64, 0x8c, 0x18, 0x54, 0x88, 0x8d, 0x65, 0xf3, 0xae, 0xdf, 0x76,
+                0x66, 0x9c, 0x4d, 0x11, 0x76, 0xf7, 0x16, 0xb8, 0xcb, 0x01, 0xe3, 0x66, 0xf9, 0xc2, 0x1d, 0x96,
+                0x26, 0x0a, 0x4f, 0x44, 0xf0, 0x55, 0x8e, 0xe9, 0x37, 0x2e, 0xd8, 0x14, 0xbb, 0xb6, 0x28, 0x24,
+                0xbc, 0x41, 0xbc, 0x60, 0xea, 0xfa, 0x66, 0x32, 0xa2, 0x67, 0x5d, 0xd9, 0x12, 0x10, 0xc4, 0x17,
+                0x5c, 0x88, 0x21, 0xf7, 0x3a, 0xea, 0xb7, 0x71, 0x14, 0x37, 0xa3, 0xaf, 0x87, 0xa6, 0x5b, 0x80,
+                0xd0, 0xa3, 0x95, 0xe6, 0xbd, 0xe0, 0xcf, 0x64, 0xd1, 0xad, 0xf8, 0x11, 0x15, 0x41, 0x6c, 0xb7,
+                0x9d, 0xe0, 0xfb, 0x65, 0x51, 0x03, 0xcf, 0xc9, 0x44, 0x66, 0xe7, 0xf7, 0x43, 0x6f, 0xf7, 0xff,
+                0x33, 0x44, 0xef, 0x18, 0x18, 0xd1, 0x48, 0xff, 0x0b, 0xc8, 0x93, 0xe9, 0x9f, 0x71, 0x5e, 0xda
+            };
+            Assert.That(signature, Is.EqualTo(expected));
+        }
+    }
+}

--- a/Src/Support/GoogleApis.Auth.Tests/app.config
+++ b/Src/Support/GoogleApis.Auth.Tests/app.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/>
   </startup>
 </configuration>

--- a/Src/Support/GoogleApis.Auth.Tests/packages.config
+++ b/Src/Support/GoogleApis.Auth.Tests/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="BouncyCastle" version="1.7.0" targetFramework="net45" />
   <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="NUnit" version="3.2.1" targetFramework="net45" />

--- a/Src/Support/GoogleApis.Auth.Tests_dotnetcore/project.json
+++ b/Src/Support/GoogleApis.Auth.Tests_dotnetcore/project.json
@@ -14,12 +14,16 @@
 
   "buildOptions": {
     "compile": {
-      "include": [ "../GoogleApis.Auth.Tests/**/*.cs" ],
+      "include": [
+        // Combining tests from both NET45 projects into one NET Core test project.
+        "../GoogleApis.Auth.Tests/**/*.cs",
+        "../GoogleApis.Auth.DotNet4.Tests/**/*.cs"
+      ],
+      "exclude": [
+        "../**/AssemblyInfo.cs", // Not needed for test, two of them collide
+      ]
     },
-    "define": [ "NETSTANDARD" ]
-  },
-
-  "compilationOptions": {
+    "define": [ "NETSTANDARD;SIGNED" ],
     "keyFile": "../../../google.apis.snk"
   },
 

--- a/Src/Support/GoogleApis.Tests/Apis/Requests/BatchRequestTest.cs
+++ b/Src/Support/GoogleApis.Tests/Apis/Requests/BatchRequestTest.cs
@@ -358,7 +358,6 @@ Content-Length: 202
             }
         }
 
-#if !NETSTANDARD // "BatchRequest.CreateOuterRequestContent" is internal
         [Test]
         public void CreateOuterRequestContent_Test()
         {
@@ -431,7 +430,6 @@ hello world
             var requestStr = BatchRequest.CreateRequestContentString(request).Result;
             Assert.AreEqual(expectedMessage, NormalizeLineEndings(requestStr));
         }
-#endif
 
         // Line endings in HttpContent are different between mono & .NET.
         private static string NormalizeLineEndings(string s) {

--- a/Src/Support/GoogleApis.Tests/Apis/Upload/ImprovedResumableUploadTest.cs
+++ b/Src/Support/GoogleApis.Tests/Apis/Upload/ImprovedResumableUploadTest.cs
@@ -586,9 +586,7 @@ namespace Google.Apis.Tests.Apis.Upload
             {
                 var content = knownSize ? new MemoryStream(uploadTestBytes) : new UnknownSizeMemoryStream(uploadTestBytes);
                 var uploader = new TestResumableUpload(service, "MultiChunk", "POST", content, "text/plain", chunkSize);
-#if !NETSTANDARD // "uploader.BufferSize" is internal
                 uploader.BufferSize = bufferSize;
-#endif
                 var progress = uploader.Upload();
                 int sanity = 0;
                 while (progress.Status == UploadStatus.Failed && sanity++ < 10)

--- a/Src/Support/GoogleApis.Tests_dotnetcore/project.json
+++ b/Src/Support/GoogleApis.Tests_dotnetcore/project.json
@@ -23,10 +23,7 @@
         "../GoogleApis.Tests/Apis/Download/**"
       ]
     },
-    "define": [ "NETSTANDARD" ]
-  },
-
-  "compilationOptions": {
+    "define": [ "NETSTANDARD;SIGNED" ],
     "keyFile": "../../../google.apis.snk"
   },
 

--- a/SupportLibraries.proj
+++ b/SupportLibraries.proj
@@ -13,6 +13,10 @@
     <NuGetConfig>$(MSBuildThisFileDirectory)NuGet.Config</NuGetConfig>
   </PropertyGroup>
   
+  <PropertyGroup>
+    <Configuration Condition="'$(Configuration)' == ''">ReleaseSigned</Configuration>
+  </PropertyGroup>
+
   <Target Name="NuGetRestore">
     <!-- restore nuget packages into packages directory, using our NuGet.Config -->
     <Exec Command="nuget restore &quot;%(SolutionFile.FullPath)&quot; -PackagesDirectory $(PackagesDir) -ConfigFile $(NuGetConfig)" />
@@ -28,7 +32,7 @@
         Projects="@(SolutionFile)"
         BuildInParallel="True"
         Targets="Build"
-        Properties="Configuration=ReleaseSigned;NugetPackagesDirectory=$(PackagesDir);NoWarn=$(NoWarn)" />
+        Properties="Configuration=$(Configuration);NugetPackagesDirectory=$(PackagesDir);NoWarn=$(NoWarn)" />
   </Target>
 
   <!--


### PR DESCRIPTION
Support ServiceAccountCredentials in netstandard, although without initialization from X509 certificate. Fixes #797.

#805 adds tests for valid AccessToken from ServiceAccountCredential.

Fixed signing in netstandard builds so InternalsVisibleTo now works. Enabled all tests in netstandard that previously were disabled due to internal access.