### PR TITLE
NET Core tests on Windows

### DIFF
--- a/run_tests_dotnetcore.bat
+++ b/run_tests_dotnetcore.bat
@@ -3,19 +3,14 @@ rem Runs the .NET Core tests locally.
 
 setlocal
 
-REM Build the support libraries.
-msbuild SupportLibraries.proj
-
-REM Clean slate after the build.
 set workspace=%~dp0
 set nugetconfig=%workspace%\NuGet.Config
-set nugetcache=%userprofile%\.nuget\packages
-
-REM Delete all Google packages from nuget cache
-forfiles /P %nugetcache% /M Google.* /C "CMD /C rmdir /S /Q @path"
 
 REM Restore the test projects.
 dotnet restore ^
+  "Src\Support\GoogleApis.Core_dotnetcore" ^
+  "Src\Support\GoogleApis_dotnetcore" ^
+  "Src\Support\GoogleApis.Auth_dotnetcore" ^
   "Src\Support\GoogleApis.Tests_dotnetcore" ^
   "Src\Support\GoogleApis.Auth.Tests_dotnetcore" ^
   --no-cache ^


### PR DESCRIPTION
Update run_tests_dotnetcore.bat to match run_tests_dotnetcore.sh, so both now use dotnet cli to build and test on Windows and Linux respectively