### PR TITLE
Fix PromptCodeRecevier on .NET Core

### DIFF
--- a/Src/Support/GoogleApis.Auth.NetStandard/project.json
+++ b/Src/Support/GoogleApis.Auth.NetStandard/project.json
@@ -5,7 +5,6 @@
     "System.Collections": "4.0.11",
     "System.Console": "4.0.0",
     "System.Diagnostics.Debug": "4.0.11",
-    "System.Diagnostics.Process": "4.1.0",
     "System.IO": "4.1.0",
     "System.IO.FileSystem": "4.0.1",
     "System.IO.FileSystem.Primitives": "4.0.1",

--- a/Src/Support/GoogleApis.Auth.PlatformServices_Shared/OAuth2/PromptCodeReceiver.cs
+++ b/Src/Support/GoogleApis.Auth.PlatformServices_Shared/OAuth2/PromptCodeReceiver.cs
@@ -15,7 +15,6 @@ limitations under the License.
 */
 
 using System;
-using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -40,8 +39,15 @@ namespace Google.Apis.Auth.OAuth2
         {
             var authorizationUrl = url.Build().ToString();
 
+#if NETSTANDARD
+            Logger.Debug("Requested user open a browser with \"{0}\" URL", authorizationUrl);
+            Console.WriteLine("Please visit the following URL in a web browser, then enter the code shown after authorization:");
+            Console.WriteLine(authorizationUrl);
+            Console.WriteLine();
+#else
             Logger.Debug("Open a browser with \"{0}\" URL", authorizationUrl);
-            Process.Start(authorizationUrl);
+            System.Diagnostics.Process.Start(authorizationUrl);
+#endif
 
             string code = string.Empty;
             while (string.IsNullOrEmpty(code))

--- a/Src/Support/GoogleApis.Auth/Google.Apis.Auth.nuspec
+++ b/Src/Support/GoogleApis.Auth/Google.Apis.Auth.nuspec
@@ -43,7 +43,6 @@
           <dependency id="System.Collections" version="4.0.11" />
           <dependency id="System.Console" version="4.0.0" />
           <dependency id="System.Diagnostics.Debug" version="4.0.11" />
-          <dependency id="System.Diagnostics.Process" version="4.1.0" />
           <dependency id="System.IO" version="4.1.0" />
           <dependency id="System.IO.FileSystem" version="4.0.1" />
           <dependency id="System.IO.FileSystem.Primitives" version="4.0.1" />

--- a/Src/Support/GoogleApis.Auth_dotnetcore/project.json
+++ b/Src/Support/GoogleApis.Auth_dotnetcore/project.json
@@ -9,7 +9,6 @@
     "System.Collections": "4.0.11",
     "System.Console": "4.0.0",
     "System.Diagnostics.Debug": "4.0.11",
-    "System.Diagnostics.Process": "4.1.0",
     "System.IO": "4.1.0",
     "System.IO.FileSystem": "4.0.1",
     "System.IO.FileSystem.Primitives": "4.0.1",


### PR DESCRIPTION
In .NET Core prompt the user to browse to the authentication URL, rather than launch a browser. Opening a URL as a process is not supported on Core. Fixes #813