### PR TITLE
Fix discovery library

### DIFF
--- a/ClientGenerator/src/googleapis/codegen/languages/csharp/default/templates/___package_name___/project.json.tmpl
+++ b/ClientGenerator/src/googleapis/codegen/languages/csharp/default/templates/___package_name___/project.json.tmpl
@@ -1,0 +1,23 @@
+{
+  "version": "{{ features.releaseVersion }}",
+
+  "dependencies": {
+    "GoogleApis_dotnetcore": { "target": "project" },
+    "GoogleApis.Core_dotnetcore": { "target": "project" },
+  },
+
+  "buildOptions": {
+    "compile": {
+      "include": [
+        "*.cs"
+      ]
+    },
+    "define": [ "NETSTANDARD;SIGNED" ],
+    "keyFile": "../../../google.apis.snk"
+  },
+
+  "frameworks": {
+    "netstandard1.3": {
+    }
+  }
+}

--- a/NuGet.Core.Config
+++ b/NuGet.Core.Config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="NuGet.org" value="https://nuget.org/api/v2/" protocolVersion="2" />
+  </packageSources>
+</configuration>

--- a/Src/Generated/Google.Apis.Discovery.v1/project.json
+++ b/Src/Generated/Google.Apis.Discovery.v1/project.json
@@ -1,0 +1,23 @@
+{
+  "version": "1.15.0",
+
+  "dependencies": {
+    "GoogleApis_dotnetcore": { "target": "project" },
+    "GoogleApis.Core_dotnetcore": { "target": "project" },
+  },
+
+  "buildOptions": {
+    "compile": {
+      "include": [
+        "*.cs"
+      ]
+    },
+    "define": [ "NETSTANDARD;SIGNED" ],
+    "keyFile": "../../../google.apis.snk"
+  },
+
+  "frameworks": {
+    "netstandard1.3": {
+    }
+  }
+}

--- a/Src/GeneratedTests/Discovery.Tests/DiscoveryTest.cs
+++ b/Src/GeneratedTests/Discovery.Tests/DiscoveryTest.cs
@@ -16,18 +16,18 @@ namespace Google.Apis.Discovery.v1.Tests
     {
         class FakeHttpMessageHandler : ConfigurableMessageHandler
         {
-            public FakeHttpMessageHandler(Dictionary<string, byte[]> data) : base(new HttpClientHandler())
+            public FakeHttpMessageHandler(Dictionary<string, HttpContent> data) : base(new HttpClientHandler())
             {
                 _data = data;
             }
 
-            private Dictionary<string, byte[]> _data;
+            private Dictionary<string, HttpContent> _data;
 
             protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
             {
                 var result = new HttpResponseMessage(System.Net.HttpStatusCode.OK)
                 {
-                    Content = new ByteArrayContent(_data[request.RequestUri.AbsolutePath])
+                    Content = _data[request.RequestUri.AbsolutePath]
                 };
                 return Task.FromResult(result);
             }
@@ -35,12 +35,12 @@ namespace Google.Apis.Discovery.v1.Tests
 
         class FakeHttpClientFactory : IHttpClientFactory
         {
-            public FakeHttpClientFactory(Dictionary<string, byte[]> data)
+            public FakeHttpClientFactory(Dictionary<string, HttpContent> data)
             {
                 _data = data;
             }
 
-            private Dictionary<string, byte[]> _data;
+            private Dictionary<string, HttpContent> _data;
 
             public ConfigurableHttpClient CreateHttpClient(CreateHttpClientArgs args)
             {
@@ -53,15 +53,10 @@ namespace Google.Apis.Discovery.v1.Tests
         {
             // Test that the "$ref" names as used by the discovery API are treated as normal names by the JSON deserializer.
             // This is the first test of a generated library.
-            var stream = GetType().GetTypeInfo().Assembly.GetManifestResourceStream("Discovery.Tests.resources.urlshortener.json");
-            string sUrlShortener;
-            using (var reader = new StreamReader(stream, Encoding.ASCII))
+            var urlShortenerStream = GetType().GetTypeInfo().Assembly.GetManifestResourceStream("Discovery.Tests.resources.urlshortener.json");
+            var data = new Dictionary<string, HttpContent>
             {
-                sUrlShortener = reader.ReadToEnd();
-            }
-            var data = new Dictionary<string, byte[]>
-            {
-                { "/discovery/v1/apis/urlshortener/v1/rest", Encoding.ASCII.GetBytes(sUrlShortener) }
+                { "/discovery/v1/apis/urlshortener/v1/rest", new StreamContent(urlShortenerStream) }
             };
             var initializer = new BaseClientService.Initializer
             {

--- a/Src/GeneratedTests/Discovery.Tests/DiscoveryTest.cs
+++ b/Src/GeneratedTests/Discovery.Tests/DiscoveryTest.cs
@@ -1,0 +1,76 @@
+using Google.Apis.Http;
+using Google.Apis.Services;
+using NUnit.Framework;
+using System.Threading.Tasks;
+using System.Net.Http;
+using System.Threading;
+using System.Collections.Generic;
+using System.Text;
+using System.Reflection;
+using System.IO;
+
+namespace Google.Apis.Discovery.v1.Tests
+{
+    [TestFixture]
+    public class DiscoveryTest
+    {
+        class FakeHttpMessageHandler : ConfigurableMessageHandler
+        {
+            public FakeHttpMessageHandler(Dictionary<string, byte[]> data) : base(new HttpClientHandler())
+            {
+                _data = data;
+            }
+
+            private Dictionary<string, byte[]> _data;
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                var result = new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+                {
+                    Content = new ByteArrayContent(_data[request.RequestUri.AbsolutePath])
+                };
+                return Task.FromResult(result);
+            }
+        }
+
+        class FakeHttpClientFactory : IHttpClientFactory
+        {
+            public FakeHttpClientFactory(Dictionary<string, byte[]> data)
+            {
+                _data = data;
+            }
+
+            private Dictionary<string, byte[]> _data;
+
+            public ConfigurableHttpClient CreateHttpClient(CreateHttpClientArgs args)
+            {
+                return new ConfigurableHttpClient(new FakeHttpMessageHandler(_data));
+            }
+        }
+
+        [Test]
+        public async Task TestUrlShortenerRef()
+        {
+            // Test that the "$ref" names as used by the discovery API are treated as normal names by the JSON deserializer.
+            // This is the first test of a generated library.
+            var stream = GetType().GetTypeInfo().Assembly.GetManifestResourceStream("Discovery.Tests.resources.urlshortener.json");
+            string sUrlShortener;
+            using (var reader = new StreamReader(stream, Encoding.ASCII))
+            {
+                sUrlShortener = reader.ReadToEnd();
+            }
+            var data = new Dictionary<string, byte[]>
+            {
+                { "/discovery/v1/apis/urlshortener/v1/rest", Encoding.ASCII.GetBytes(sUrlShortener) }
+            };
+            var initializer = new BaseClientService.Initializer
+            {
+                HttpClientFactory = new FakeHttpClientFactory(data)
+            };
+            var service = new DiscoveryService(initializer);
+            var urlshortener = await service.Apis.GetRest("urlshortener", "v1").ExecuteAsync();
+            Assert.That(urlshortener.Id, Is.EqualTo("urlshortener:v1"));
+            Assert.That(urlshortener.Schemas["AnalyticsSnapshot"].Properties["browsers"].Items.Ref__, Is.EqualTo("StringCount"));
+        }
+    }
+}

--- a/Src/GeneratedTests/Discovery.Tests/project.json
+++ b/Src/GeneratedTests/Discovery.Tests/project.json
@@ -1,0 +1,36 @@
+{
+  "version": "1.0.0-*",
+
+  "dependencies": {
+    "Google.Apis.Discovery.v1": { "target": "project" },
+    "Nunit": "3.4.0",
+    "dotnet-test-nunit": "3.4.0-beta-1"
+  },
+
+  "buildOptions": {
+    "compile": {
+      "include":  [ "**/*.cs" ]
+    },
+    "embed": {
+      "include": [ "resources/**" ]
+    },
+    "define": [ "NETSTANDARD;SIGNED" ],
+    "keyFile": "../../../google.apis.snk"
+  },
+
+  "testRunner": "nunit",
+
+  "frameworks": {
+    "netcoreapp1.0": {
+      "imports": [
+        "portable-net45+win8"
+      ],
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "version": "1.0.0-*",
+          "type": "platform"
+        }
+      }
+    }
+  }
+}

--- a/Src/GeneratedTests/Discovery.Tests/resources/urlshortener.json
+++ b/Src/GeneratedTests/Discovery.Tests/resources/urlshortener.json
@@ -1,0 +1,319 @@
+﻿{
+  "kind": "discovery#restDescription",
+  "etag": "\"C5oy1hgQsABtYOYIOXWcR3BgYqU/1HSXgVbkO3Z5Y9cbiE9dhFdbqxk\"",
+  "discoveryVersion": "v1",
+  "id": "urlshortener:v1",
+  "name": "urlshortener",
+  "version": "v1",
+  "revision": "20150519",
+  "title": "URL Shortener API",
+  "description": "Lets you create, inspect, and manage goo.gl short URLs",
+  "ownerDomain": "google.com",
+  "ownerName": "Google",
+  "icons": {
+    "x16": "http://www.google.com/images/icons/product/search-16.gif",
+    "x32": "http://www.google.com/images/icons/product/search-32.gif"
+  },
+  "documentationLink": "https://developers.google.com/url-shortener/v1/getting_started",
+  "protocol": "rest",
+  "baseUrl": "https://www.googleapis.com/urlshortener/v1/",
+  "basePath": "/urlshortener/v1/",
+  "rootUrl": "https://www.googleapis.com/",
+  "servicePath": "urlshortener/v1/",
+  "batchPath": "batch",
+  "parameters": {
+    "alt": {
+      "type": "string",
+      "description": "Data format for the response.",
+      "default": "json",
+      "enum": [
+        "json"
+      ],
+      "enumDescriptions": [
+        "Responses with Content-Type of application/json"
+      ],
+      "location": "query"
+    },
+    "fields": {
+      "type": "string",
+      "description": "Selector specifying which fields to include in a partial response.",
+      "location": "query"
+    },
+    "key": {
+      "type": "string",
+      "description": "API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.",
+      "location": "query"
+    },
+    "oauth_token": {
+      "type": "string",
+      "description": "OAuth 2.0 token for the current user.",
+      "location": "query"
+    },
+    "prettyPrint": {
+      "type": "boolean",
+      "description": "Returns response with indentations and line breaks.",
+      "default": "true",
+      "location": "query"
+    },
+    "quotaUser": {
+      "type": "string",
+      "description": "Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters. Overrides userIp if both are provided.",
+      "location": "query"
+    },
+    "userIp": {
+      "type": "string",
+      "description": "IP address of the site where the request originates. Use this if you want to enforce per-user limits.",
+      "location": "query"
+    }
+  },
+  "auth": {
+    "oauth2": {
+      "scopes": {
+        "https://www.googleapis.com/auth/urlshortener": {
+          "description": "Manage your goo.gl short URLs"
+        }
+      }
+    }
+  },
+  "schemas": {
+    "AnalyticsSnapshot": {
+      "id": "AnalyticsSnapshot",
+      "type": "object",
+      "properties": {
+        "browsers": {
+          "type": "array",
+          "description": "Top browsers, e.g. \"Chrome\"; sorted by (descending) click counts. Only present if this data is available.",
+          "items": {
+            "$ref": "StringCount"
+          }
+        },
+        "countries": {
+          "type": "array",
+          "description": "Top countries (expressed as country codes), e.g. \"US\" or \"DE\"; sorted by (descending) click counts. Only present if this data is available.",
+          "items": {
+            "$ref": "StringCount"
+          }
+        },
+        "longUrlClicks": {
+          "type": "string",
+          "description": "Number of clicks on all goo.gl short URLs pointing to this long URL.",
+          "format": "int64"
+        },
+        "platforms": {
+          "type": "array",
+          "description": "Top platforms or OSes, e.g. \"Windows\"; sorted by (descending) click counts. Only present if this data is available.",
+          "items": {
+            "$ref": "StringCount"
+          }
+        },
+        "referrers": {
+          "type": "array",
+          "description": "Top referring hosts, e.g. \"www.google.com\"; sorted by (descending) click counts. Only present if this data is available.",
+          "items": {
+            "$ref": "StringCount"
+          }
+        },
+        "shortUrlClicks": {
+          "type": "string",
+          "description": "Number of clicks on this short URL.",
+          "format": "int64"
+        }
+      }
+    },
+    "AnalyticsSummary": {
+      "id": "AnalyticsSummary",
+      "type": "object",
+      "properties": {
+        "allTime": {
+          "$ref": "AnalyticsSnapshot",
+          "description": "Click analytics over all time."
+        },
+        "day": {
+          "$ref": "AnalyticsSnapshot",
+          "description": "Click analytics over the last day."
+        },
+        "month": {
+          "$ref": "AnalyticsSnapshot",
+          "description": "Click analytics over the last month."
+        },
+        "twoHours": {
+          "$ref": "AnalyticsSnapshot",
+          "description": "Click analytics over the last two hours."
+        },
+        "week": {
+          "$ref": "AnalyticsSnapshot",
+          "description": "Click analytics over the last week."
+        }
+      }
+    },
+    "StringCount": {
+      "id": "StringCount",
+      "type": "object",
+      "properties": {
+        "count": {
+          "type": "string",
+          "description": "Number of clicks for this top entry, e.g. for this particular country or browser.",
+          "format": "int64"
+        },
+        "id": {
+          "type": "string",
+          "description": "Label assigned to this top entry, e.g. \"US\" or \"Chrome\"."
+        }
+      }
+    },
+    "Url": {
+      "id": "Url",
+      "type": "object",
+      "properties": {
+        "analytics": {
+          "$ref": "AnalyticsSummary",
+          "description": "A summary of the click analytics for the short and long URL. Might not be present if not requested or currently unavailable."
+        },
+        "created": {
+          "type": "string",
+          "description": "Time the short URL was created; ISO 8601 representation using the yyyy-MM-dd'T'HH:mm:ss.SSSZZ format, e.g. \"2010-10-14T19:01:24.944+00:00\"."
+        },
+        "id": {
+          "type": "string",
+          "description": "Short URL, e.g. \"http://goo.gl/l6MS\"."
+        },
+        "kind": {
+          "type": "string",
+          "description": "The fixed string \"urlshortener#url\".",
+          "default": "urlshortener#url"
+        },
+        "longUrl": {
+          "type": "string",
+          "description": "Long URL, e.g. \"http://www.google.com/\". Might not be present if the status is \"REMOVED\"."
+        },
+        "status": {
+          "type": "string",
+          "description": "Status of the target URL. Possible values: \"OK\", \"MALWARE\", \"PHISHING\", or \"REMOVED\". A URL might be marked \"REMOVED\" if it was flagged as spam, for example."
+        }
+      }
+    },
+    "UrlHistory": {
+      "id": "UrlHistory",
+      "type": "object",
+      "properties": {
+        "items": {
+          "type": "array",
+          "description": "A list of URL resources.",
+          "items": {
+            "$ref": "Url"
+          }
+        },
+        "itemsPerPage": {
+          "type": "integer",
+          "description": "Number of items returned with each full \"page\" of results. Note that the last page could have fewer items than the \"itemsPerPage\" value.",
+          "format": "int32"
+        },
+        "kind": {
+          "type": "string",
+          "description": "The fixed string \"urlshortener#urlHistory\".",
+          "default": "urlshortener#urlHistory"
+        },
+        "nextPageToken": {
+          "type": "string",
+          "description": "A token to provide to get the next page of results."
+        },
+        "totalItems": {
+          "type": "integer",
+          "description": "Total number of short URLs associated with this user (may be approximate).",
+          "format": "int32"
+        }
+      }
+    }
+  },
+  "resources": {
+    "url": {
+      "methods": {
+        "get": {
+          "id": "urlshortener.url.get",
+          "path": "url",
+          "httpMethod": "GET",
+          "description": "Expands a short URL or gets creation time and analytics.",
+          "parameters": {
+            "projection": {
+              "type": "string",
+              "description": "Additional information to return.",
+              "enum": [
+                "ANALYTICS_CLICKS",
+                "ANALYTICS_TOP_STRINGS",
+                "FULL"
+              ],
+              "enumDescriptions": [
+                "Returns only click counts.",
+                "Returns only top string counts.",
+                "Returns the creation timestamp and all available analytics."
+              ],
+              "location": "query"
+            },
+            "shortUrl": {
+              "type": "string",
+              "description": "The short URL, including the protocol.",
+              "required": true,
+              "location": "query"
+            }
+          },
+          "parameterOrder": [
+            "shortUrl"
+          ],
+          "response": {
+            "$ref": "Url"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/urlshortener"
+          ]
+        },
+        "insert": {
+          "id": "urlshortener.url.insert",
+          "path": "url",
+          "httpMethod": "POST",
+          "description": "Creates a new short URL.",
+          "request": {
+            "$ref": "Url"
+          },
+          "response": {
+            "$ref": "Url"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/urlshortener"
+          ]
+        },
+        "list": {
+          "id": "urlshortener.url.list",
+          "path": "url/history",
+          "httpMethod": "GET",
+          "description": "Retrieves a list of URLs shortened by a user.",
+          "parameters": {
+            "projection": {
+              "type": "string",
+              "description": "Additional information to return.",
+              "enum": [
+                "ANALYTICS_CLICKS",
+                "FULL"
+              ],
+              "enumDescriptions": [
+                "Returns short URL click counts.",
+                "Returns short URL click counts."
+              ],
+              "location": "query"
+            },
+            "start-token": {
+              "type": "string",
+              "description": "Token for requesting successive pages of results.",
+              "location": "query"
+            }
+          },
+          "response": {
+            "$ref": "UrlHistory"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/urlshortener"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/Src/Support/GoogleApis.Core/Apis/Json/NewtonsoftJsonSerializer.cs
+++ b/Src/Support/GoogleApis.Core/Apis/Json/NewtonsoftJsonSerializer.cs
@@ -59,7 +59,7 @@ namespace Google.Apis.Json
     /// <summary>Class for serialization and deserialization of JSON documents using the Newtonsoft Library.</summary>
     public class NewtonsoftJsonSerializer : IJsonSerializer
     {
-        private static readonly JsonSerializerSettings s_settings;
+        private static readonly JsonSerializerSettings newtonsoftSettings;
         private static readonly JsonSerializer newtonsoftSerializer;
 
         private static NewtonsoftJsonSerializer instance;
@@ -76,13 +76,13 @@ namespace Google.Apis.Json
         static NewtonsoftJsonSerializer()
         {
             // Initialize the Newtonsoft serializer.
-            s_settings = new JsonSerializerSettings
+            newtonsoftSettings = new JsonSerializerSettings
             {
                 NullValueHandling = NullValueHandling.Ignore,
                 MetadataPropertyHandling = MetadataPropertyHandling.Ignore,
                 Converters = { new RFC3339DateTimeConverter() }
             };
-            newtonsoftSerializer = JsonSerializer.Create(s_settings);
+            newtonsoftSerializer = JsonSerializer.Create(newtonsoftSettings);
         }
 
         public string Format
@@ -121,7 +121,7 @@ namespace Google.Apis.Json
             {
                 return default(T);
             }
-            return JsonConvert.DeserializeObject<T>(input, s_settings);
+            return JsonConvert.DeserializeObject<T>(input, newtonsoftSettings);
         }
 
         public object Deserialize(string input, Type type)
@@ -130,7 +130,7 @@ namespace Google.Apis.Json
             {
                 return null;
             }
-            return JsonConvert.DeserializeObject(input, type, s_settings);
+            return JsonConvert.DeserializeObject(input, type, newtonsoftSettings);
         }
 
         public T Deserialize<T>(Stream input)

--- a/Src/Support/GoogleApis.Core/Apis/Json/NewtonsoftJsonSerializer.cs
+++ b/Src/Support/GoogleApis.Core/Apis/Json/NewtonsoftJsonSerializer.cs
@@ -59,6 +59,7 @@ namespace Google.Apis.Json
     /// <summary>Class for serialization and deserialization of JSON documents using the Newtonsoft Library.</summary>
     public class NewtonsoftJsonSerializer : IJsonSerializer
     {
+        private static readonly JsonSerializerSettings s_settings;
         private static readonly JsonSerializer newtonsoftSerializer;
 
         private static NewtonsoftJsonSerializer instance;
@@ -75,10 +76,13 @@ namespace Google.Apis.Json
         static NewtonsoftJsonSerializer()
         {
             // Initialize the Newtonsoft serializer.
-            JsonSerializerSettings settings = new JsonSerializerSettings();
-            settings.NullValueHandling = NullValueHandling.Ignore;
-            settings.Converters.Add(new RFC3339DateTimeConverter());
-            newtonsoftSerializer = JsonSerializer.Create(settings);
+            s_settings = new JsonSerializerSettings
+            {
+                NullValueHandling = NullValueHandling.Ignore,
+                MetadataPropertyHandling = MetadataPropertyHandling.Ignore,
+                Converters = { new RFC3339DateTimeConverter() }
+            };
+            newtonsoftSerializer = JsonSerializer.Create(s_settings);
         }
 
         public string Format
@@ -117,7 +121,7 @@ namespace Google.Apis.Json
             {
                 return default(T);
             }
-            return JsonConvert.DeserializeObject<T>(input);
+            return JsonConvert.DeserializeObject<T>(input, s_settings);
         }
 
         public object Deserialize(string input, Type type)
@@ -126,7 +130,7 @@ namespace Google.Apis.Json
             {
                 return null;
             }
-            return JsonConvert.DeserializeObject(input, type);
+            return JsonConvert.DeserializeObject(input, type, s_settings);
         }
 
         public T Deserialize<T>(Stream input)

--- a/Src/global.json
+++ b/Src/global.json
@@ -1,5 +1,8 @@
 {
-  "projects": [ "Support" ],
+  "projects": [
+    "Support",
+    "Generated"
+  ],
   "sdk": {
     "version": "1.0.0-preview2-003121"
   }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,9 +23,7 @@ build_script:
   - dotnet --info
   - msbuild SupportLibraries.proj
   - .\testrunner\NUnit.ConsoleRunner.3.2.1\tools\nunit3-console.exe Src\Support\GoogleApis.Tests\bin\ReleaseSigned\Google.Apis.Tests.exe Src\Support\GoogleApis.Auth.Tests\bin\ReleaseSigned\Google.Apis.Auth.Tests.exe Src\Support\GoogleApis.Auth.DotNet4.Tests\bin\ReleaseSigned\Google.Apis.Auth.DotNet4.Tests.exe
-  - dotnet restore .\Src\Support --configfile .\NuGet.Config
-  - dotnet test .\Src\Support\GoogleApis.Tests_dotnetcore
-  - dotnet test .\Src\Support\GoogleApis.Auth.Tests_dotnetcore
+  - run_tests_dotnetcore.bat
 
 # The tests are run as part of the build.
 test: off

--- a/run_tests_dotnetcore.bat
+++ b/run_tests_dotnetcore.bat
@@ -1,23 +1,25 @@
 @echo off
-rem Runs the .NET Core tests locally.
+rem Runs the .NET Core tests locally (Windows).
 
 setlocal
 
 set workspace=%~dp0
-set nugetconfig=%workspace%\NuGet.Config
+set nugetconfig=%workspace%\NuGet.Core.Config
 
-REM Restore the test projects.
-dotnet restore ^
-  "Src\Support\GoogleApis.Core_dotnetcore" ^
-  "Src\Support\GoogleApis_dotnetcore" ^
-  "Src\Support\GoogleApis.Auth_dotnetcore" ^
-  "Src\Support\GoogleApis.Tests_dotnetcore" ^
-  "Src\Support\GoogleApis.Auth.Tests_dotnetcore" ^
-  --no-cache ^
-  --configfile "%nugetconfig%"
+REM Restore support libraries and tests.
+dotnet restore "Src\Support\GoogleApis.Core_dotnetcore\project.json" --configfile "%nugetconfig%"
+dotnet restore "Src\Support\GoogleApis_dotnetcore\project.json" --configfile "%nugetconfig%"
+dotnet restore "Src\Support\GoogleApis.Auth_dotnetcore\project.json" --configfile "%nugetconfig%"
+dotnet restore "Src\Support\GoogleApis.Tests_dotnetcore\project.json" --configfile "%nugetconfig%"
+dotnet restore "Src\Support\GoogleApis.Auth.Tests_dotnetcore\project.json" --configfile "%nugetconfig%"
 
-REM Run the tests.
-dotnet test "Src\Support\GoogleApis.Tests_dotnetcore"
+REM Restore generated libraries and tests.
+dotnet restore "Src\Generated\Google.Apis.Discovery.v1\project.json" --configfile "%nugetconfig%"
+dotnet restore "Src\GeneratedTests\Discovery.Tests\project.json" --configfile "%nugetconfig%"
+
+REM Test support libraries.
+dotnet test "Src\Support\GoogleApis.Tests_dotnetcore\project.json"
 dotnet test "Src\Support\GoogleApis.Auth.Tests_dotnetcore"
 
-echo Done.
+REM Test generated libraries.
+dotnet test "Src\GeneratedTests\Discovery.Tests"

--- a/run_tests_dotnetcore.sh
+++ b/run_tests_dotnetcore.sh
@@ -1,12 +1,22 @@
 #!/bin/bash
+# Runs the .NET Core tests locally (Linux).
 
 set -e
 
-dotnet restore Src/Support/GoogleApis.Core_dotnetcore --configfile NuGet.Linux.Config
-dotnet restore Src/Support/GoogleApis_dotnetcore --configfile NuGet.Linux.Config
-dotnet restore Src/Support/GoogleApis.Auth_dotnetcore --configfile NuGet.Linux.Config
-dotnet restore Src/Support/GoogleApis.Tests_dotnetcore --configfile NuGet.Linux.Config
-dotnet restore Src/Support/GoogleApis.Auth.Tests_dotnetcore --configfile NuGet.Linux.Config
+# Restore support libraries and tests.
+dotnet restore Src/Support/GoogleApis.Core_dotnetcore --configfile NuGet.Core.Config
+dotnet restore Src/Support/GoogleApis_dotnetcore --configfile NuGet.Core.Config
+dotnet restore Src/Support/GoogleApis.Auth_dotnetcore --configfile NuGet.Core.Config
+dotnet restore Src/Support/GoogleApis.Tests_dotnetcore --configfile NuGet.Core.Config
+dotnet restore Src/Support/GoogleApis.Auth.Tests_dotnetcore --configfile NuGet.Core.Config
 
+# Restore generated libraries and tests.
+dotnet restore Src/Generated/Google.Apis.Discovery.v1 --configfile NuGet.Core.Config
+dotnet restore Src/GeneratedTests/Discovery.Tests --configfile NuGet.Core.Config
+
+# Test support libraries.
 dotnet test Src/Support/GoogleApis.Tests_dotnetcore
 dotnet test Src/Support/GoogleApis.Auth.Tests_dotnetcore
+
+# Test generated libraries.
+dotnet test Src/GeneratedTests/Discovery.Tests


### PR DESCRIPTION
Fix the Google.Apis.Discovery.v1 generated library by disabling metadata property handling (ie ) in the JSON deserializer. Fixes #79

Adds a test for the Discovery generated library, for .NET Core only at the moment

Generates a project.json for all generated libraries with a netstandard build. Currently only used for the discovery test

Add the generated code test to the run_test_dotnetcore.* scripts