### PR TITLE
Support net46

### DIFF
--- a/ClientGenerator/src/googleapis/codegen/languages/csharp/default/features.json
+++ b/ClientGenerator/src/googleapis/codegen/languages/csharp/default/features.json
@@ -1,7 +1,7 @@
 {
   "language": "csharp",
   "description": "C# libraries for Google APIs.",
-  "releaseVersion": "1.16.0",
-  "nugetVersion": "1.16.0",
+  "releaseVersion": "1.17.0",
+  "nugetVersion": "1.17.0",
   "oldCompatibleVersion": "1.10.0"
 }

--- a/ClientGenerator/src/googleapis/codegen/languages/csharp/default/templates/___package_name___/Net45/___package_name___.csproj.tmpl
+++ b/ClientGenerator/src/googleapis/codegen/languages/csharp/default/templates/___package_name___/Net45/___package_name___.csproj.tmpl
@@ -53,14 +53,6 @@
       <HintPath>..\..\packages\Google.Apis.{{ features.releaseVersion }}\lib\net45\Google.Apis.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <!--<Reference Include="Google.Apis.PlatformServices, Version=1.16.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Apis.1.16.0\lib\net45\Google.Apis.PlatformServices.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="log4net, Version=1.2.13.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
-      <HintPath>..\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>
-      <Private>True</Private>
-    </Reference>-->
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>

--- a/ClientGenerator/src/googleapis/codegen/languages/csharp/default/templates/___package_name___/Net45/___package_name___.csproj.tmpl
+++ b/ClientGenerator/src/googleapis/codegen/languages/csharp/default/templates/___package_name___/Net45/___package_name___.csproj.tmpl
@@ -1,0 +1,92 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{3033D28A-0541-4BCA-AF66-C2C9459CA98A}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>{{ api.module.name }}</RootNamespace>
+    <AssemblyName>{{ api.module.name }}</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <DocumentationFile>{{ api.module.name }}.xml</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'ReleaseSigned|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\ReleaseSigned\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <SignAssembly>True</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\..\..\..\google.apis.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="..\{{ api.module.name }}.cs"/>
+    <Compile Include="..\Properties\AssemblyInfo.cs"/>
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="Google.Apis.Core">
+      <HintPath>..\..\packages\Google.Apis.Core.{{ features.releaseVersion }}\lib\net45\Google.Apis.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Google.Apis">
+      <HintPath>..\..\packages\Google.Apis.{{ features.releaseVersion }}\lib\net45\Google.Apis.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <!--<Reference Include="Google.Apis.PlatformServices, Version=1.16.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Apis.1.16.0\lib\net45\Google.Apis.PlatformServices.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="log4net, Version=1.2.13.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>
+      <Private>True</Private>
+    </Reference>-->
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+    <Reference Include="Zlib.Portable">
+      <HintPath>..\..\packages\Zlib.Portable.Signed.1.11.0\lib\portable-net4+sl5+wp8+win8+wpa81+MonoTouch+MonoAndroid\Zlib.Portable.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/ClientGenerator/src/googleapis/codegen/languages/csharp/default/templates/___package_name___/Net45/packages.config.tmpl
+++ b/ClientGenerator/src/googleapis/codegen/languages/csharp/default/templates/___package_name___/Net45/packages.config.tmpl
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Google.Apis" version="1.16.0" targetFramework="net45" />
+  <package id="Google.Apis.Core" version="1.16.0" targetFramework="net45" />
+  <package id="log4net" version="2.0.3" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
+  <package id="Zlib.Portable.Signed" version="1.11.0" targetFramework="net45" />
+</packages>

--- a/ClientGenerator/src/googleapis/codegen/languages/csharp/default/templates/___package_name___/Net45/packages.config.tmpl
+++ b/ClientGenerator/src/googleapis/codegen/languages/csharp/default/templates/___package_name___/Net45/packages.config.tmpl
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Google.Apis" version="1.16.0" targetFramework="net45" />
-  <package id="Google.Apis.Core" version="1.16.0" targetFramework="net45" />
+  <package id="Google.Apis" version="{{ features.releaseVersion }}" targetFramework="net45" />
+  <package id="Google.Apis.Core" version="{{ features.releaseVersion }}" targetFramework="net45" />
   <package id="log4net" version="2.0.3" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="Zlib.Portable.Signed" version="1.11.0" targetFramework="net45" />

--- a/ClientGenerator/src/googleapis/codegen/languages/csharp/default/templates/___package_name___/___package_name___.nuspec.tmpl
+++ b/ClientGenerator/src/googleapis/codegen/languages/csharp/default/templates/___package_name___/___package_name___.nuspec.tmpl
@@ -14,7 +14,7 @@
           Google APIs Client Library for working with {% camel_case api.name %} {{ api.version }}.
           Supported Platforms:
 
-          - .NET Framework 4 and 4.5
+          - .NET Framework 4 and 4.5+
 
           - NetStandard1.3
 
@@ -33,6 +33,10 @@
         <tags>Google</tags>
         <dependencies>
             <group targetFramework="netstandard1.3">
+                <dependency id="Google.Apis" version="{{ features.releaseVersion }}" />{% if api.authscopes %}
+                <dependency id="Google.Apis.Auth" version="{{ features.releaseVersion }}" />{% endif %}
+            </group>
+            <group targetFramework="net45">
                 <dependency id="Google.Apis" version="{{ features.releaseVersion }}" />{% if api.authscopes %}
                 <dependency id="Google.Apis.Auth" version="{{ features.releaseVersion }}" />{% endif %}
             </group>
@@ -57,6 +61,10 @@
         <file src="NetStandard\bin\ReleaseSigned\{{ api.module.name }}.dll" target="lib\netstandard1.3\{{ api.module.name }}.dll" />
         <file src="NetStandard\bin\ReleaseSigned\{{ api.module.name }}.pdb" target="lib\netstandard1.3\{{ api.module.name }}.pdb" />
         <file src="NetStandard\bin\ReleaseSigned\{{ api.module.name }}.xml" target="lib\netstandard1.3\{{ api.module.name }}.xml" />
+
+        <file src="Net45\bin\ReleaseSigned\{{ api.module.name }}.dll" target="lib\net45\{{ api.module.name }}.dll" />
+        <file src="Net45\bin\ReleaseSigned\{{ api.module.name }}.pdb" target="lib\net45\{{ api.module.name }}.pdb" />
+        <file src="Net45\bin\ReleaseSigned\{{ api.module.name }}.xml" target="lib\net45\{{ api.module.name }}.xml" />
 
         <file src="Profile259\bin\ReleaseSigned\{{ api.module.name }}.dll" target="lib\portable-net45+netcore45+wpa81+wp8\{{ api.module.name }}.dll" />
         <file src="Profile259\bin\ReleaseSigned\{{ api.module.name }}.pdb" target="lib\portable-net45+netcore45+wpa81+wp8\{{ api.module.name }}.pdb" />

--- a/Src/Support/CommonAssemblyInfo.cs
+++ b/Src/Support/CommonAssemblyInfo.cs
@@ -21,7 +21,7 @@ using System.Reflection;
 [assembly: AssemblyCompany("Google Inc")]
 [assembly: AssemblyCopyright("Copyright 2016 Google Inc")]
 
-[assembly: AssemblyVersion("1.16.0.0")]
+[assembly: AssemblyVersion("1.17.0.0")]
 
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]


### PR DESCRIPTION
Add a net45 target to the generated library nupkgs, which is used by net46 builds rather than the netstandard1.3 target.
This will also be used by net45 projects, but that should essentially be a no-op.
Fixes #845.