### PR TITLE
Add a Range property to MediaDownloader to allow ranged downloads

### DIFF
--- a/Src/Support/GoogleApis.Tests/Apis/Download/MediaDownloaderTest.cs
+++ b/Src/Support/GoogleApis.Tests/Apis/Download/MediaDownloaderTest.cs
@@ -173,8 +173,6 @@ namespace Google.Apis.Tests.Apis.Download
                     outStream.Position = 0;
 
                     // Provide rudimentary, non-robust support for Range.
-                    // MediaDownloader doesn't exercise this code anymore, but it was useful for
-                    // testing previous implementations that did. It remains for posterity.
                     string rangeHeader = context.Request.Headers["Range"];
                     if (rangeHeader != null && response.StatusCode == (int)HttpStatusCode.OK)
                     {
@@ -291,6 +289,31 @@ namespace Google.Apis.Tests.Apis.Download
         {
             Subtest_Download_Chunks(2, false, 3);
             Subtest_Download_Chunks(MediaContent.Length - 1, false, 1);
+        }
+
+        [Test]
+        public void DownloadRange()
+        {
+            using (var service = new MockClientService())
+            {
+                int startInclusive = 5;
+                int endInclusive = 13;
+                var downloader = new MediaDownloader(service);
+                downloader.Range = new RangeHeaderValue(startInclusive, endInclusive);
+                var outputStream = new MemoryStream();
+                var result = downloader.Download(_httpPrefix + "content", outputStream);
+
+                Assert.AreEqual(result.Status, DownloadStatus.Completed);
+                Assert.IsNull(result.Exception);
+                Assert.AreEqual(result.BytesDownloaded, outputStream.Position);
+
+                byte[] bytes = outputStream.ToArray();
+                Assert.AreEqual(endInclusive - startInclusive + 1, bytes.Length);
+                for (int i = 0; i < bytes.Length; i++)
+                {
+                    Assert.AreEqual(MediaContent[i + startInclusive], bytes[i]);
+                }
+            }
         }
 
         /// <summary>

--- a/Src/Support/GoogleApis.Tests/Apis/Download/MediaDownloaderTest.cs
+++ b/Src/Support/GoogleApis.Tests/Apis/Download/MediaDownloaderTest.cs
@@ -309,10 +309,8 @@ namespace Google.Apis.Tests.Apis.Download
 
                 byte[] bytes = outputStream.ToArray();
                 Assert.AreEqual(endInclusive - startInclusive + 1, bytes.Length);
-                for (int i = 0; i < bytes.Length; i++)
-                {
-                    Assert.AreEqual(MediaContent[i + startInclusive], bytes[i]);
-                }
+                byte[] expectedBytes = MediaContent.Skip(startInclusive).Take(bytes.Length).ToArray();
+                Assert.AreEqual(expectedBytes, bytes);
             }
         }
 

--- a/Src/Support/GoogleApis/Apis/[Media]/Download/MediaDownloader.cs
+++ b/Src/Support/GoogleApis/Apis/[Media]/Download/MediaDownloader.cs
@@ -24,6 +24,7 @@ using Google.Apis.Logging;
 using Google.Apis.Media;
 using Google.Apis.Services;
 using Google.Apis.Util;
+using System.Net.Http.Headers;
 
 namespace Google.Apis.Download
 {
@@ -66,6 +67,12 @@ namespace Google.Apis.Download
                 chunkSize = value;
             }
         }
+
+        /// <summary>
+        /// The range header for the request, if any. This can be used to download specific parts
+        /// of the requested media.
+        /// </summary>
+        public RangeHeaderValue Range { get; set; }
 
         #region Progress
 
@@ -241,6 +248,7 @@ namespace Google.Apis.Download
             }
 
             var request = new HttpRequestMessage(HttpMethod.Get, uri.ToString());
+            request.Headers.Range = Range;
 
             // Number of bytes sent to the caller's stream.
             long bytesReturned = 0;


### PR DESCRIPTION
This is only in MediaDownloader rather than IMediaDownloader for
backward compatibility, but it can be added to the interface in v2.