### PR TITLE
Bug 874

### DIFF
--- a/Src/Support/GoogleApis.Auth.DotNet4.Tests/GoogleApis.Auth.PlatformServices.Tests_Net45.csproj
+++ b/Src/Support/GoogleApis.Auth.DotNet4.Tests/GoogleApis.Auth.PlatformServices.Tests_Net45.csproj
@@ -49,10 +49,6 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="BouncyCastle.Crypto, Version=1.7.4137.9688, Culture=neutral, PublicKeyToken=a4292a325f69b123, processorArchitecture=MSIL">
-      <HintPath>..\packages\BouncyCastle.1.7.0\lib\Net40-Client\BouncyCastle.Crypto.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Moq, Version=4.2.1402.2112, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\packages\Moq.4.2.1402.2112\lib\net40\Moq.dll</HintPath>
       <Private>True</Private>

--- a/Src/Support/GoogleApis.Auth.DotNet4.Tests/packages.config
+++ b/Src/Support/GoogleApis.Auth.DotNet4.Tests/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="BouncyCastle" version="1.7.0" targetFramework="net45" />
   <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="NUnit" version="3.2.1" targetFramework="net45" />

--- a/Src/Support/GoogleApis.Auth.DotNet4/GoogleApis.Auth.PlatformServices_Net45.csproj
+++ b/Src/Support/GoogleApis.Auth.DotNet4/GoogleApis.Auth.PlatformServices_Net45.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -97,6 +97,31 @@
   </ItemGroup>
   <Import Project="..\GoogleApis.Auth.PlatformServices_Shared\GoogleApis.Auth.PlatformServices_Shared.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\ILRepack.MSBuild.Task.1.0.9\build\ILRepack.MSBuild.Task.targets" Condition="Exists('..\packages\ILRepack.MSBuild.Task.1.0.9\build\ILRepack.MSBuild.Task.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\ILRepack.MSBuild.Task.1.0.9\build\ILRepack.MSBuild.Task.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\ILRepack.MSBuild.Task.1.0.9\build\ILRepack.MSBuild.Task.targets'))" />
+  </Target>
+  <!-- ILRepack -->
+  <Target Name="AfterBuild">
+    <Message Importance="High" Text="ILMerge start....." />
+    <PropertyGroup>
+      <ILRepackDebug>$(DebugSymbols)</ILRepackDebug>
+      <ILRepackPrimaryAssemblyFile>$(OutputPath)$(TargetName)$(TargetExt)</ILRepackPrimaryAssemblyFile>
+    </PropertyGroup>
+    <ItemGroup>
+      <InputAssemblies Include="$(ILRepackPrimaryAssemblyFile)" />
+      <InputAssemblies Include="$(OutputPath)\BouncyCastle.Crypto.dll" />
+    </ItemGroup>
+    <Message Importance="High" Text="Merging @(InputAssemblies) ==&gt; $(ILRepackPrimaryAssemblyFile)" />
+    <Message Importance="High" Text="Debug: $(ILRepackDebug)" />
+    <Message Importance="High" Text="Key File: $(AssemblyOriginatorKeyFile)" />
+    <ILRepack Parallel="true" Internalize="true" PrimaryAssemblyFile="$(ILRepackPrimaryAssemblyFile)" InputAssemblies="@(InputAssemblies)" TargetKind="Dll" DebugInfo="$(ILRepackDebug)" OutputFile="$(ILRepackPrimaryAssemblyFile)" KeyFile="$(AssemblyOriginatorKeyFile)" />
+    <Message Importance="High" Text="ILMerge done." />
+  </Target>
+  <!-- /ILRepack -->
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Src/Support/GoogleApis.Auth.DotNet4/packages.config
+++ b/Src/Support/GoogleApis.Auth.DotNet4/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="BouncyCastle" version="1.7.0" targetFramework="net45" />
+  <package id="ILRepack.MSBuild.Task" version="1.0.9" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
 </packages>

--- a/Src/Support/GoogleApis.Auth/Google.Apis.Auth.nuspec
+++ b/Src/Support/GoogleApis.Auth/Google.Apis.Auth.nuspec
@@ -31,9 +31,10 @@
           <!--
             BouncyCastle is required by the Net45 version of
             Google.Apis.Auth.PlatformServices.
-          -->
-          <dependency id="BouncyCastle" version="1.7.0" />
 
+            The library was included to a static dependency due to Bug #874
+            https://github.com/google/google-api-dotnet-client/issues/874
+          -->
           <dependency id="Google.Apis" version="$version$" />
           <dependency id="Google.Apis.Core" version="$version$" />
         </group>


### PR DESCRIPTION
Proposed solution for #874 that links BouncyCastle 1.7.0 statically (internalizes all BouncyCastle types and code within the Google.Apis.Auth.PlatformServices.dll and removes the need for an external dependency of any version)

https://github.com/google/google-api-dotnet-client/issues/874