### PR TITLE
Avoid using system local time anywhere

### DIFF
--- a/Src/Support/GoogleApis.Auth/OAuth2/Requests/TokenRequestExtenstions.cs
+++ b/Src/Support/GoogleApis.Auth/OAuth2/Requests/TokenRequestExtenstions.cs
@@ -59,7 +59,7 @@ namespace Google.Apis.Auth.OAuth2.Requests
 
             // Gets the token and sets its issued time.
             var newToken = NewtonsoftJsonSerializer.Instance.Deserialize<TokenResponse>(content);
-            newToken.Issued = clock.Now;
+            newToken.IssuedUtc = clock.UtcNow;
             return newToken;
         }
     }

--- a/Src/Support/GoogleApis.Core/Apis/Util/IClock.cs
+++ b/Src/Support/GoogleApis.Core/Apis/Util/IClock.cs
@@ -25,6 +25,7 @@ namespace Google.Apis.Util
         /// Gets a <see cref="System.DateTime"/> object that is set to the current date and time on this computer, 
         /// expressed as the local time.
         /// </summary>
+        [Obsolete("System local time is almost always inappropriate to use. If you really need this, call UtcNow and then call ToLocalTime on the result")]
         DateTime Now { get; }
 
         /// <summary>
@@ -34,7 +35,10 @@ namespace Google.Apis.Util
         DateTime UtcNow { get; }
     }
 
-    /// <summary>A default clock implementation that wraps the <see cref="System.DateTime.Now"/> property.</summary>
+    /// <summary>
+    /// A default clock implementation that wraps the <see cref="System.DateTime.UtcNow"/>
+    /// and <see cref="System.DateTime.Now"/> properties.
+    /// </summary>
     public class SystemClock : IClock
     {
         /// <summary>Constructs a new system clock.</summary>
@@ -43,14 +47,8 @@ namespace Google.Apis.Util
         /// <summary>The default instance.</summary>
         public static readonly IClock Default = new SystemClock();
 
-        public DateTime Now
-        {
-            get { return DateTime.Now; }
-        }
+        public DateTime Now => DateTime.Now;
 
-        public DateTime UtcNow
-        {
-            get { return DateTime.UtcNow; }
-        }
+        public DateTime UtcNow => DateTime.UtcNow;
     }
 }

--- a/Src/Support/GoogleApis.Tests/Apis/Http/ConfigurableMessageHandlerTest.cs
+++ b/Src/Support/GoogleApis.Tests/Apis/Http/ConfigurableMessageHandlerTest.cs
@@ -125,8 +125,8 @@ namespace Google.Apis.Tests.Apis.Http
             using (var client = new HttpClient(configurableHanlder))
             {
                 var request = new HttpRequestMessage(HttpMethod.Get, location);
-                request.Headers.IfModifiedSince = new DateTimeOffset(DateTime.Now);
-                request.Headers.IfUnmodifiedSince = new DateTimeOffset(DateTime.Now);
+                request.Headers.IfModifiedSince = DateTimeOffset.UtcNow;
+                request.Headers.IfUnmodifiedSince = DateTimeOffset.UtcNow;
                 request.Headers.IfMatch.Add(new EntityTagHeaderValue("\"a\""));
                 request.Headers.IfNoneMatch.Add(new EntityTagHeaderValue("\"b\""));
 
@@ -157,8 +157,8 @@ namespace Google.Apis.Tests.Apis.Http
             using (var client = new HttpClient(configurableHanlder))
             {
                 var request = new HttpRequestMessage(HttpMethod.Get, location);
-                request.Headers.IfModifiedSince = new DateTimeOffset(DateTime.Now);
-                request.Headers.IfUnmodifiedSince = new DateTimeOffset(DateTime.Now);
+                request.Headers.IfModifiedSince = DateTimeOffset.UtcNow;
+                request.Headers.IfUnmodifiedSince = DateTimeOffset.UtcNow;
                 request.Headers.IfMatch.Add(new EntityTagHeaderValue("\"a\""));
                 request.Headers.IfNoneMatch.Add(new EntityTagHeaderValue("\"b\""));
 

--- a/Src/Support/GoogleApis.Tests/[Mock]/MockClock.cs
+++ b/Src/Support/GoogleApis.Tests/[Mock]/MockClock.cs
@@ -20,10 +20,18 @@ using Google.Apis.Util;
 
 namespace Google.Apis.Tests
 {
-    /// <summary>A mock clock which you can get and set its current time.</summary>
+    /// <summary>
+    /// A mock clock which allows you to set its current time. The two
+    /// properties are linked - changes to one are reflected in the other.
+    /// </summary>
     public class MockClock : IClock
     {
-        public DateTime Now { get; set; }
+        public DateTime Now
+        {
+            get { return UtcNow.ToLocalTime(); }
+            set { UtcNow = value.ToUniversalTime(); }
+        }
+
         public DateTime UtcNow { get; set; }
     }
 }


### PR DESCRIPTION
This mostly concerns TokenReponse which was maintaining a local
issued time, causing issues in terms of validation around DST
transitions.

In general, we should be discouraging the use of system local time;
it's almost never appropriate, particularly when making API calls.

Unfortunately the system local time will have been persisted in JSON
in auth stores; this change avoids breaking such persisted data, by
always storing the existing property (so old code can read it) and
reading it where necessary.

Fixes #884.