### PR TITLE
Add a convenience method to obtain a GoogleCredential from a JSON string

### DIFF
--- a/Src/Support/GoogleApis.Auth.DotNet4.Tests/OAuth2/GoogleCredentialTests.cs
+++ b/Src/Support/GoogleApis.Auth.DotNet4.Tests/OAuth2/GoogleCredentialTests.cs
@@ -74,6 +74,21 @@ ZUp8AsbVqF6rbLiiUfJMo2btGclQu4DEVyS+ymFA65tXDLUuR9EDqJYdqHNZJ5B8
             Assert.IsTrue(credential.IsCreateScopedRequired);
         }
 
+        [Test]
+        public void FromJson_UserCredential()
+        {
+            var credential = GoogleCredential.FromJson(DummyUserCredentialFileContents);
+            Assert.IsFalse(credential.IsCreateScopedRequired);
+        }
+
+        [Test]
+        public void FromJson_ServiceAccountCredential()
+        {
+            var credential = GoogleCredential.FromJson(DummyServiceAccountCredentialFileContents);
+            Assert.IsInstanceOf(typeof(ServiceAccountCredential), credential.UnderlyingCredential);
+            Assert.IsTrue(credential.IsCreateScopedRequired);
+        }
+
         /// <summary>
         /// Creates service account credential from stream, obtains a JWT token
         /// from the credential and checks the access token is well-formed.

--- a/Src/Support/GoogleApis.Auth.PlatformServices_Shared/OAuth2/DefaultCredentialProvider.cs
+++ b/Src/Support/GoogleApis.Auth.PlatformServices_Shared/OAuth2/DefaultCredentialProvider.cs
@@ -172,19 +172,35 @@ namespace Google.Apis.Auth.OAuth2
             {
                 throw new InvalidOperationException("Error deserializing JSON credential data.", e);
             }
-            return CreateDefaultCredentialFromJson(credentialParameters);
+            return CreateDefaultCredentialFromParameters(credentialParameters);
         }
 
+        /// <summary>Creates a default credential from a string that contains JSON credential data.</summary>
+        internal GoogleCredential CreateDefaultCredentialFromJson(string json)
+        {
+            JsonCredentialParameters credentialParameters;
+            try
+            {
+                credentialParameters = NewtonsoftJsonSerializer.Instance.Deserialize<JsonCredentialParameters>(json);
+            }
+            catch (Exception e)
+            {
+                throw new InvalidOperationException("Error deserializing JSON credential data.", e);
+            }
+            return CreateDefaultCredentialFromParameters(credentialParameters);
+        }
+
+
         /// <summary>Creates a default credential from JSON data.</summary>
-        private static GoogleCredential CreateDefaultCredentialFromJson(JsonCredentialParameters credentialParameters)
+        private static GoogleCredential CreateDefaultCredentialFromParameters(JsonCredentialParameters credentialParameters)
         {
             switch (credentialParameters.Type)
             {
                 case JsonCredentialParameters.AuthorizedUserCredentialType:
-                    return new GoogleCredential(CreateUserCredentialFromJson(credentialParameters));
+                    return new GoogleCredential(CreateUserCredentialFromParameters(credentialParameters));
                 case JsonCredentialParameters.ServiceAccountCredentialType:
                     return GoogleCredential.FromCredential(
-                        CreateServiceAccountCredentialFromJson(credentialParameters));
+                        CreateServiceAccountCredentialFromParameters(credentialParameters));
                 default:
                     throw new InvalidOperationException(
                         String.Format("Error creating credential from JSON. Unrecognized credential type {0}.", 
@@ -193,7 +209,7 @@ namespace Google.Apis.Auth.OAuth2
         }
 
         /// <summary>Creates a user credential from JSON data.</summary>
-        private static UserCredential CreateUserCredentialFromJson(JsonCredentialParameters credentialParameters)
+        private static UserCredential CreateUserCredentialFromParameters(JsonCredentialParameters credentialParameters)
         {
             if (credentialParameters.Type != JsonCredentialParameters.AuthorizedUserCredentialType ||
                 string.IsNullOrEmpty(credentialParameters.ClientId) ||
@@ -220,7 +236,7 @@ namespace Google.Apis.Auth.OAuth2
         }
 
         /// <summary>Creates a <see cref="ServiceAccountCredential"/> from JSON data.</summary>
-        private static ServiceAccountCredential CreateServiceAccountCredentialFromJson(
+        private static ServiceAccountCredential CreateServiceAccountCredentialFromParameters(
             JsonCredentialParameters credentialParameters)
         {
             if (credentialParameters.Type != JsonCredentialParameters.ServiceAccountCredentialType ||

--- a/Src/Support/GoogleApis.Auth.PlatformServices_Shared/OAuth2/GoogleCredential.cs
+++ b/Src/Support/GoogleApis.Auth.PlatformServices_Shared/OAuth2/GoogleCredential.cs
@@ -99,6 +99,18 @@ namespace Google.Apis.Auth.OAuth2
         }
 
         /// <summary>
+        /// Loads credential from a string containing JSON credential data.
+        /// <para>
+        /// The string can contain a Service Account key file in JSON format from the Google Developers
+        /// Console or a stored user credential using the format supported by the Cloud SDK.
+        /// </para>
+        /// </summary>
+        public static GoogleCredential FromJson(string json)
+        {
+            return defaultCredentialProvider.CreateDefaultCredentialFromJson(json);
+        }
+
+        /// <summary>
         /// <para>Returns <c>true</c> only if this credential type has no scopes by default and requires
         /// a call to <see cref="o:CreateScoped"/> before use.</para>
         ///


### PR DESCRIPTION
Existing private `*FromJson` methods have been renamed for clarity.