### PR TITLE
Remove local directory from nuget config

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -2,7 +2,6 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="LocalSupport" value="NuPkgs\Support" />
     <add key="NuGet.org" value="https://nuget.org/api/v2/" protocolVersion="2" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
This appears to be confusing AppVeyor, and we don't really need it.