### PR TITLE
Allow modification of HTTP requests for download and client requests

### DIFF
--- a/Src/Support/GoogleApis/Apis/Requests/ClientServiceRequest.cs
+++ b/Src/Support/GoogleApis/Apis/Requests/ClientServiceRequest.cs
@@ -49,6 +49,11 @@ namespace Google.Apis.Requests
         /// <summary>Defines whether the E-Tag will be used in a specified way or be ignored.</summary>
         public ETagAction ETagAction { get; set; }
 
+        /// <summary>
+        /// Gets or sets the callback for modifying HTTP requests made by this service request.
+        /// </summary>
+        public Action<HttpRequestMessage> ModifyRequest { get; set; }
+
         #region IClientServiceRequest Properties
 
         public abstract string MethodName { get; }
@@ -187,6 +192,7 @@ namespace Google.Apis.Requests
             request.SetRequestSerailizedContent(service, body, overrideGZipEnabled.HasValue
                 ? overrideGZipEnabled.Value : service.GZipEnabled);
             AddETag(request);
+            ModifyRequest?.Invoke(request);
             return request;
         }
 

--- a/Src/Support/GoogleApis/Apis/[Media]/Download/MediaDownloader.cs
+++ b/Src/Support/GoogleApis/Apis/[Media]/Download/MediaDownloader.cs
@@ -127,6 +127,11 @@ namespace Google.Apis.Download
             this.service = service;
         }
 
+        /// <summary>
+        /// Gets or sets the callback for modifying requests made when downloading.
+        /// </summary>
+        public Action<HttpRequestMessage> ModifyRequest { get; set; }
+
         #region IMediaDownloader Overrides
 
         public event Action<IDownloadProgress> ProgressChanged;
@@ -249,6 +254,7 @@ namespace Google.Apis.Download
 
             var request = new HttpRequestMessage(HttpMethod.Get, uri.ToString());
             request.Headers.Range = Range;
+            ModifyRequest?.Invoke(request);
 
             // Number of bytes sent to the caller's stream.
             long bytesReturned = 0;


### PR DESCRIPTION
Upload already supports this for the initial session negotiation via ResumableUploadOptions.

(Testing this explicitly looks like more effort than it's worth - let me know if you disagree. We'll soon have integration tests in google-cloud-dotnet that would fail if the code broke...)