### PR TITLE
Updates GoogleConsts.cs adding the new OpenIDConnect compliant  endPoints

### DIFF
--- a/Src/Support/GoogleApis.Auth/OAuth2/GoogleConsts.cs
+++ b/Src/Support/GoogleApis.Auth/OAuth2/GoogleConsts.cs
@@ -20,13 +20,13 @@ namespace Google.Apis.Auth.OAuth2
     public static class GoogleAuthConsts
     {
         /// <summary>The authorization code server URL.</summary>
-        public const string AuthorizationUrl = "https://accounts.google.com/o/oauth2/auth";
+        public const string AuthorizationUrl = "https://accounts.google.com/o/oauth2/v2/auth";
 
         /// <summary>The approval URL (used in the Windows solution as a callback).</summary>
         public const string ApprovalUrl = "https://accounts.google.com/o/oauth2/approval";
 
         /// <summary>The authorization token server URL.</summary>
-        public const string TokenUrl = "https://accounts.google.com/o/oauth2/token";
+        public const string TokenUrl = "https://www.googleapis.com/oauth2/v4/token";
 
         /// <summary>The Compute Engine authorization token server URL</summary>
         public const string ComputeTokenUrl =


### PR DESCRIPTION
This is in reference to issue [#916](https://github.com/google/google-api-dotnet-client/issues/916)

I did a quick test using the google plus API.   I was able to authenticate.   

Waiting to hear from @jtattermusch  about any possible issues this may cause.
   