### PR TITLE
Use HttpClientFactory to create HttpClient in ResumableUpload

### DIFF
--- a/Src/Support/GoogleApis/Apis/[Media]/Upload/ResumableUpload.cs
+++ b/Src/Support/GoogleApis/Apis/[Media]/Upload/ResumableUpload.cs
@@ -86,7 +86,7 @@ namespace Google.Apis.Upload
             ContentStream = contentStream;
             // Check if the stream length is known.
             StreamLength = ContentStream.CanSeek ? ContentStream.Length : UnknownSize;
-            HttpClient = options?.ConfigurableHttpClient ?? new ConfigurableHttpClient(new ConfigurableMessageHandler(new HttpClientHandler()));
+            HttpClient = options?.ConfigurableHttpClient ?? new HttpClientFactory().CreateHttpClient(new CreateHttpClientArgs { ApplicationName = "ResumableUpload", GZipEnabled = true });
             Options = options;
         }
 


### PR DESCRIPTION
This allows the inner HttpClientHandler to have auto-redirect
disabled, which makes a difference on at least some imlpementations
of .NET Core.

// cc @evildour

Fixes #930.