### PR TITLE
Use batchPath from discovery-doc

### DIFF
--- a/ClientGenerator/src/googleapis/codegen/api.py
+++ b/ClientGenerator/src/googleapis/codegen/api.py
@@ -328,6 +328,16 @@ class Api(template_objects.CodeObject):
     if service_path is None:
       self._api.SetTemplateValue('servicePath', base_path[1:])
 
+    batch_path = self.values.get('batchPath')
+    if batch_path:
+      batch_path = batch_path.lstrip('/')
+      if batch_path:
+        self._api.SetTemplateValue('batchPath', batch_path)
+      else:
+        self._api.SetTemplateValue('batchPath', None)
+    else:
+      self._api.SetTemplateValue('batchPath', None)
+
     # Make sure template writers do not revert
     self._api.DeleteTemplateValue('baseUrl')
     self._api.DeleteTemplateValue('basePath')

--- a/ClientGenerator/src/googleapis/codegen/api_test.py
+++ b/ClientGenerator/src/googleapis/codegen/api_test.py
@@ -414,6 +414,22 @@ class ApiTest(basetest.TestCase):
     # no servicePath
     self.assertRaises(ValueError, LoadApi, {'rootUrl': 'https://foo.com/'})
 
+    # batchPath
+    api = LoadApi({})
+    self.assertEquals(None, api.values['batchPath'])
+    api = LoadApi({
+        'batchPath': 'batch'
+    })
+    self.assertEquals("batch", api.values['batchPath'])
+    api = LoadApi({
+        'batchPath': '/batch'
+    })
+    self.assertEquals("batch", api.values['batchPath'])
+    api = LoadApi({
+        'batchPath': '//batch'
+    })
+    self.assertEquals("batch", api.values['batchPath'])
+
   def testCanonicalName(self):
     d = {'name': 'fake', 'version': 'v1', 'canonicalName': 'My API'}
     api = Api(d)

--- a/ClientGenerator/src/googleapis/codegen/languages/csharp/default/templates/___package_name___/___package_name___.cs.tmpl
+++ b/ClientGenerator/src/googleapis/codegen/languages/csharp/default/templates/___package_name___/___package_name___.cs.tmpl
@@ -98,6 +98,24 @@ public override string BasePath
     get { return "{{ api.servicePath }}"; }
 }
 
+/// <summary>Gets the batch base URI; <c>null</c> if unspecified.</summary>
+public override string BatchUri
+{
+{% noblank %}{% if api.batchPath %}
+    get { return "{{ api.rootUrl }}{{ api.batchPath }}"; }
+{% else %}
+    get { return null; }
+{% endif %}{% endnoblank %}}
+
+/// <summary>Gets the batch base path; <c>null</c> if unspecified.</summary>
+public override string BatchPath
+{
+{% noblank %}{% if api.batchPath %}
+    get { return "{{ api.batchPath }}"; }
+{% else %}
+    get { return null; }
+{% endif %}{% endnoblank %}}
+
 {% if api.authscopes %}/// <summary>Available OAuth 2.0 scopes for use with the {{ api.title }}.</summary>
 public class Scope
 {

--- a/ClientGenerator/src/googleapis/codegen/testdata/golden_discovery/kitchen_sink.json
+++ b/ClientGenerator/src/googleapis/codegen/testdata/golden_discovery/kitchen_sink.json
@@ -5,6 +5,7 @@
  "rootUrl": "https://www.googleapis.com/",
  "servicePath" : "sink/v1/",
  "rpcPath": "/rpc",
+ "batchPath": "batch",
  "features": [
   "dataWrapper"
  ],

--- a/Src/Generated/Google.Apis.Discovery.v1/Google.Apis.Discovery.v1.cs
+++ b/Src/Generated/Google.Apis.Discovery.v1/Google.Apis.Discovery.v1.cs
@@ -91,9 +91,15 @@ namespace Google.Apis.Discovery.v1
             get { return "discovery/v1/"; }
         }
 
+        public override string BatchUri
+        {
+            get { return "https://www.googleapis.com/batch"; }
+        }
 
-
-
+        public override string BatchPath
+        {
+            get { return "batch"; }
+        }
 
         private readonly ApisResource apis;
 

--- a/Src/Generated/Google.Apis.Storage.v1/Google.Apis.Storage.v1.cs
+++ b/Src/Generated/Google.Apis.Storage.v1/Google.Apis.Storage.v1.cs
@@ -98,6 +98,18 @@ namespace Google.Apis.Storage.v1
             get { return "storage/v1/"; }
         }
 
+        /// <summary>Gets the batch base URI; <c>null</c> if unspecified.</summary>
+        public override string BatchUri
+        {
+            get { return "https://www.googleapis.com/batch"; }
+        }
+
+        /// <summary>Gets the batch base path; <c>null</c> if unspecified.</summary>
+        public override string BatchPath
+        {
+            get { return "batch"; }
+        }
+
         /// <summary>Available OAuth 2.0 scopes for use with the Cloud Storage JSON API.</summary>
         public class Scope
         {

--- a/Src/Support/GoogleApis.Tests/Apis/Requests/BatchRequestTest.cs
+++ b/Src/Support/GoogleApis.Tests/Apis/Requests/BatchRequestTest.cs
@@ -431,6 +431,21 @@ hello world
             Assert.AreEqual(expectedMessage, NormalizeLineEndings(requestStr));
         }
 
+        [Test]
+        public void BatchUrl()
+        {
+            using (var service = new MockClientService("http://sample.com", "http://batch.sample.com"))
+            {
+                var batch = new BatchRequest(service);
+                Assert.That(batch.BatchUrl, Is.EqualTo("http://batch.sample.com"));
+            }
+            using (var service = new MockClientService("http://sample.com", null))
+            {
+                var batch = new BatchRequest(service);
+                Assert.That(batch.BatchUrl, Is.EqualTo("https://www.googleapis.com/batch"));
+            }
+        }
+
         // Line endings in HttpContent are different between mono & .NET.
         private static string NormalizeLineEndings(string s) {
             return Regex.Replace(s, @"\r\n|\n", "\r\n");

--- a/Src/Support/GoogleApis.Tests/[Mock]/MockClientService.cs
+++ b/Src/Support/GoogleApis.Tests/[Mock]/MockClientService.cs
@@ -31,23 +31,26 @@ namespace Google.Apis.Tests
     {
         public override string Name { get { return "TestService"; } }
 
-        private string _baseUri;
-        public override string BaseUri { get { return _baseUri; } }
-        public override string BasePath { get { return string.Empty; } }
+        public override string BaseUri { get; }
+        public override string BasePath => "";
+        public override string BatchUri { get; }
+        public override string BatchPath => "";
 
         private IList<string> _features = new List<string> { "rest", "rpc", "json", "atom" };
         public override IList<string> Features { get { return _features; } }
         public void SetFeatures(IList<string> features) { _features = features; }
 
-        public MockClientService(string baseUri = @"https://testexample.google.com")
-            : this(new Initializer(), baseUri)
+        public MockClientService(string baseUri = @"https://testexample.google.com", string batchUri = null)
+            : this(new Initializer(), baseUri, batchUri)
         {
         }
 
-        public MockClientService(Initializer initializer, string baseUri = @"https://testexample.google.com")
+        public MockClientService(Initializer initializer,
+            string baseUri = @"https://testexample.google.com", string batchUri = null)
             : base(initializer)
         {
-            _baseUri = baseUri;
+            BaseUri = baseUri;
+            BatchUri = batchUri;
         }
 
         protected override BackOffHandler CreateBackOffHandler()

--- a/Src/Support/GoogleApis/Apis/Requests/BatchRequest.cs
+++ b/Src/Support/GoogleApis/Apis/Requests/BatchRequest.cs
@@ -52,6 +52,9 @@ namespace Google.Apis.Requests
         private readonly string batchUrl;
         private readonly IClientService service;
 
+        // For testing
+        internal string BatchUrl => batchUrl;
+
         /// <summary>A concrete type callback for an individual response.</summary>
         /// <typeparam name="TResponse">The response type.</typeparam>
         /// <param name="content">The content response or <c>null</c> if the request failed.</param>
@@ -116,7 +119,7 @@ namespace Google.Apis.Requests
         /// <see cref="BatchRequest(IClientService, string)"/> for more information.
         /// </summary>
         public BatchRequest(IClientService service)
-            : this(service, DefaultBatchUrl) { }
+            : this(service, (service as BaseClientService)?.BatchUri ?? DefaultBatchUrl) { }
 
         /// <summary>
         /// Constructs a new batch request using the given service. The service's HTTP client is used to create a 

--- a/Src/Support/GoogleApis/Apis/Services/BaseClientService.cs
+++ b/Src/Support/GoogleApis/Apis/Services/BaseClientService.cs
@@ -309,6 +309,8 @@ namespace Google.Apis.Services
         public abstract string Name { get; }
         public abstract string BaseUri { get; }
         public abstract string BasePath { get; }
+        public abstract string BatchUri { get; }
+        public abstract string BatchPath { get; }
 
         public abstract IList<string> Features { get; }
 

--- a/Src/Support/IntegrationTests_NetCore/Google.Apis.Storage.v1.cs
+++ b/Src/Support/IntegrationTests_NetCore/Google.Apis.Storage.v1.cs
@@ -96,6 +96,18 @@ namespace Google.Apis.Storage.v1
             get { return "storage/v1/"; }
         }
 
+        /// <summary>Gets the batch base URI; <c>null</c> if unspecified.</summary>
+        public override string BatchUri
+        {
+            get { return "https://www.googleapis.com/batch"; }
+        }
+ 
+        /// <summary>Gets the batch base path; <c>null</c> if unspecified.</summary>
+        public override string BatchPath
+        {
+            get { return "batch"; }
+        }
+
         /// <summary>Available OAuth 2.0 scopes for use with the Cloud Storage JSON API.</summary>
         public class Scope
         {


### PR DESCRIPTION
Only falls back to hard-coded value if batchPath not in discovery-doc

Fixes #923. Fixes #620