### PR TITLE
Update newtonsoft.json dep to latest (10.0.2)

### DIFF
--- a/Src/Support/Google.Apis.Auth.Tests/Google.Apis.Auth.Tests.csproj
+++ b/Src/Support/Google.Apis.Auth.Tests/Google.Apis.Auth.Tests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="xunit" Version="2.3.0-beta2-build3683" />
     <PackageReference Include="Xunit.Combinatorial" Version="1.2.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta2-build1317" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
     <PackageReference Include="Moq" Version="4.7.8" />
     <ProjectReference Include="..\Google.Apis.Auth\Google.Apis.Auth.csproj" />
     <ProjectReference Include="..\Google.Apis\Google.Apis.csproj" />

--- a/Src/Support/Google.Apis.Core/Google.Apis.Core.csproj
+++ b/Src/Support/Google.Apis.Core/Google.Apis.Core.csproj
@@ -23,15 +23,14 @@ Supported Platforms:
   <!-- package references; common then per-target -->
   <ItemGroup>
     <PackageReference Include="System.Net.Http" Version="4.3.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard1.3'">
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net45'">
-    <PackageReference Include="Newtonsoft.Json" Version="7.0.1" />
   </ItemGroup>
 
 </Project>

--- a/Src/Support/Google.Apis.Tests/Google.Apis.Tests.csproj
+++ b/Src/Support/Google.Apis.Tests/Google.Apis.Tests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="xunit" Version="2.3.0-beta2-build3683" />
     <PackageReference Include="Xunit.Combinatorial" Version="1.2.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta2-build1317" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
     <ProjectReference Include="..\Google.Apis\Google.Apis.csproj" />
     <ProjectReference Include="..\Google.Apis.Core\Google.Apis.Core.csproj" />
   </ItemGroup>

--- a/Src/Support/Google.Apis/Google.Apis.csproj
+++ b/Src/Support/Google.Apis/Google.Apis.csproj
@@ -24,16 +24,15 @@ Supported Platforms:
   <!-- package references; common then per-target -->
   <ItemGroup>
     <PackageReference Include="System.Net.Http" Version="4.3.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
     <ProjectReference Include="..\Google.Apis.Core\Google.Apis.Core.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard1.3'">
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net45'">
-    <PackageReference Include="Newtonsoft.Json" Version="7.0.1" />
   </ItemGroup>
   
   <!-- build and include the (empty) platformservices dll in package; required for backward compatibility -->

--- a/Src/Support/IntegrationTests/IntegrationTests.csproj
+++ b/Src/Support/IntegrationTests/IntegrationTests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="xunit" Version="2.3.0-beta2-build3683" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta2-build1317" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
     <ProjectReference Include="..\Google.Apis.Auth\Google.Apis.Auth.csproj" />
     <ProjectReference Include="..\Google.Apis.Tests\Google.Apis.Tests.csproj" />
     <ProjectReference Include="..\Google.Apis\Google.Apis.csproj" />


### PR DESCRIPTION
This is nominally a breaking change, but Newtonsoft.Json is backward compatible across major versions in the way we use it.

Fixes #980