### PR TITLE
Fix csprojs to contain literal TargetFrameworks

### DIFF
--- a/Src/Support/CommonProjectProperties.xml
+++ b/Src/Support/CommonProjectProperties.xml
@@ -14,9 +14,7 @@
   
   <!-- common build configuration -->
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
-    <!-- On non-Windows platforms only net core can be built -->
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard1.3</TargetFrameworks>
+    <!-- TargetFrameworks cannot be here, VS fails to load project -->
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <AssemblyOriginatorKeyFile>..\..\..\google.apis.snk</AssemblyOriginatorKeyFile>

--- a/Src/Support/Google.Apis.Auth.Mvc/Google.Apis.Auth.Mvc.csproj
+++ b/Src/Support/Google.Apis.Auth.Mvc/Google.Apis.Auth.Mvc.csproj
@@ -12,7 +12,6 @@
 
   <!-- build configuration -->
   <PropertyGroup>
-    <!-- VS2017 project load fails if this is in an Import -->
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net45</TargetFrameworks>
     <!-- If not on Windows, target netstandard1.3, just to allow the empty build to succeed -->
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard1.3</TargetFrameworks>

--- a/Src/Support/Google.Apis.Auth.PlatformServices/Google.Apis.Auth.PlatformServices.csproj
+++ b/Src/Support/Google.Apis.Auth.PlatformServices/Google.Apis.Auth.PlatformServices.csproj
@@ -3,6 +3,8 @@
   <Import Project="..\CommonProjectProperties.xml" />
 
   <PropertyGroup>
+    <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard1.3</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/Src/Support/Google.Apis.Auth/Google.Apis.Auth.csproj
+++ b/Src/Support/Google.Apis.Auth/Google.Apis.Auth.csproj
@@ -4,8 +4,8 @@
 
   <!-- build configuration -->
   <PropertyGroup>
-    <!-- VS2017 project load fails if this is in an Import -->
-    <TargetFrameworks>$(TargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard1.3</TargetFrameworks>
   </PropertyGroup>
 
   <!-- nupkg information -->

--- a/Src/Support/Google.Apis.Core/Google.Apis.Core.csproj
+++ b/Src/Support/Google.Apis.Core/Google.Apis.Core.csproj
@@ -4,8 +4,8 @@
 
   <!-- build configuration -->
   <PropertyGroup>
-    <!-- VS2017 project load fails if this is in an Import -->
-    <TargetFrameworks>$(TargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard1.3</TargetFrameworks>
   </PropertyGroup>
 
   <!-- nupkg information -->

--- a/Src/Support/Google.Apis.PlatformServices/Google.Apis.PlatformServices.csproj
+++ b/Src/Support/Google.Apis.PlatformServices/Google.Apis.PlatformServices.csproj
@@ -3,6 +3,8 @@
   <Import Project="..\CommonProjectProperties.xml" />
 
   <PropertyGroup>
+    <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard1.3</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/Src/Support/Google.Apis/Google.Apis.csproj
+++ b/Src/Support/Google.Apis/Google.Apis.csproj
@@ -4,8 +4,8 @@
 
   <!-- build configuration -->
   <PropertyGroup>
-    <!-- VS2017 project load fails if this is in an Import -->
-    <TargetFrameworks>$(TargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard1.3</TargetFrameworks>
   </PropertyGroup>
 
   <!-- nupkg information -->


### PR DESCRIPTION
VS fails to load if these aren't literals in the csproj files