### PR TITLE
Add download method that returns final download status

### DIFF
--- a/ClientGenerator/src/googleapis/codegen/languages/csharp/default/templates/_method.tmpl
+++ b/ClientGenerator/src/googleapis/codegen/languages/csharp/default/templates/_method.tmpl
@@ -134,9 +134,17 @@ public override string RestPath
 public Google.Apis.Download.IMediaDownloader MediaDownloader { get; private set; }
 
 /// <summary>Synchronously download the media into the given stream.</summary>
+[System.Obsolete("This method hides errors; use " + nameof(Download2) + "(), which returns the final download status.")]
 public virtual void Download(System.IO.Stream stream)
 {
     MediaDownloader.Download(this.GenerateRequestUri(), stream);
+}
+
+/// <summary>Synchronously download the media into the given stream.</summary>
+/// <returns>The final status of the download; including whether the download succeeded or failed.</returns>
+public virtual Google.Apis.Download.IDownloadProgress Download2(System.IO.Stream stream)
+{
+    return MediaDownloader.Download(this.GenerateRequestUri(), stream);
 }
 
 /// <summary>Asynchronously download the media into the given stream.</summary>

--- a/ClientGenerator/src/googleapis/codegen/languages/csharp/default/templates/_method.tmpl
+++ b/ClientGenerator/src/googleapis/codegen/languages/csharp/default/templates/_method.tmpl
@@ -133,8 +133,10 @@ public override string RestPath
 /// <summary>Gets the media downloader.</summary>
 public Google.Apis.Download.IMediaDownloader MediaDownloader { get; private set; }
 
-/// <summary>Synchronously download the media into the given stream.</summary>
-[System.Obsolete("This method hides errors; use " + nameof(Download2) + "(), which returns the final download status.")]
+/// <summary>
+/// <para>Synchronously download the media into the given stream.</para>
+/// <para>Warning: This method hides download errors; use <see cref="DownloadWithStatus"/> instead.</para>
+/// </summary>
 public virtual void Download(System.IO.Stream stream)
 {
     MediaDownloader.Download(this.GenerateRequestUri(), stream);
@@ -142,7 +144,7 @@ public virtual void Download(System.IO.Stream stream)
 
 /// <summary>Synchronously download the media into the given stream.</summary>
 /// <returns>The final status of the download; including whether the download succeeded or failed.</returns>
-public virtual Google.Apis.Download.IDownloadProgress Download2(System.IO.Stream stream)
+public virtual Google.Apis.Download.IDownloadProgress DownloadWithStatus(System.IO.Stream stream)
 {
     return MediaDownloader.Download(this.GenerateRequestUri(), stream);
 }


### PR DESCRIPTION
And mark as Obsolete the method that swallows all errors, and does not return status.

Fixes #982