### PR TITLE
Allow response data to be intercepted before decompression

### DIFF
--- a/Src/Support/Google.Apis.Core/Google.Apis.Core.csproj
+++ b/Src/Support/Google.Apis.Core/Google.Apis.Core.csproj
@@ -33,4 +33,9 @@ Supported Platforms:
   <ItemGroup Condition="'$(TargetFramework)'=='net45'">
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="../../../third_party/System.Net.Http/GzipDeflateHandler.cs" />
+    <Compile Include="../../../third_party/System.Net.Http/StreamReplacingHttpContent.cs" />
+  </ItemGroup>
+  
 </Project>

--- a/Src/Support/Google.Apis.Core/Http/ConfigurableMessageHandler.cs
+++ b/Src/Support/Google.Apis.Core/Http/ConfigurableMessageHandler.cs
@@ -60,6 +60,11 @@ namespace Google.Apis.Http
         /// </summary>
         public const string ExecuteInterceptorKey = "__ExecuteInterceptorKey";
 
+        /// <summary>
+        /// Key for a stream response interceptor provider in an <see cref="HttpRequestMessage"/> properties.
+        /// </summary>
+        public const string ResponseStreamInterceptorProviderKey = "__ResponseStreamInterceptorProviderKey";
+
         /// <summary>The current API version of this client library.</summary>
         private static readonly string ApiVersion = Google.Apis.Util.Utilities.GetLibraryVersion();
 

--- a/Src/Support/Google.Apis.Core/Http/HttpClientFactory.cs
+++ b/Src/Support/Google.Apis.Core/Http/HttpClientFactory.cs
@@ -14,13 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net.Http;
-using System.Text;
-
 using Google.Apis.Logging;
+using System.Net;
+using System.Net.Http;
 
 namespace Google.Apis.Http
 {
@@ -53,25 +49,55 @@ namespace Google.Apis.Http
         /// <summary>Creates a HTTP message handler. Override this method to mock a message handler.</summary>
         protected virtual HttpMessageHandler CreateHandler(CreateHttpClientArgs args)
         {
-            var handler = new HttpClientHandler();
+            // We need to handle three situations in order to intercept uncompressed data where necessary
+            // while using the built-in decompression where possible.
+            // - No compression requested
+            // - Compression requested but not supported by HttpClientHandler (easy; just GzipDeflateHandler on top of an interceptor on top of HttpClientHandler)
+            // - Compression requested and HttpClientHandler (complex: create two different handlers and decide which to use on a per-request basis)
 
-            // If the framework supports redirect configuration, set it to false, because ConfigurableMessageHandler 
-            // handles redirect.
+            var clientHandler = CreateSimpleClientHandler();
+
+            if (!args.GZipEnabled)
+            {
+                // Simple: nothing will be decompressing content, so we can just intercept the original handler.
+                return new StreamInterceptionHandler(clientHandler);
+            }
+            else if (!clientHandler.SupportsAutomaticDecompression)
+            {
+                // Simple: we have to create our own decompression handler anyway, so there's still just a single chain.
+                var interceptionHandler = new StreamInterceptionHandler(clientHandler);
+                return new GzipDeflateHandler(interceptionHandler);
+            }
+            else
+            {
+                // Complex: we want to use a simple handler with no interception but with built-in decompression
+                // for requests that wouldn't perform interception anyway, and a longer chain for interception cases.
+                clientHandler.AutomaticDecompression = DecompressionMethods.Deflate | DecompressionMethods.GZip;
+
+                return new TwoWayDelegatingHandler(
+                    // Normal handler (with built-in decompression) when there's no interception.
+                    clientHandler,
+                    // Alternative handler for requests that might be intercepted, and need that interception to happen
+                    // before decompression. We need to delegate to a new client handler that *doesn't* 
+                    new GzipDeflateHandler(new StreamInterceptionHandler(CreateSimpleClientHandler())),
+                    request => StreamInterceptionHandler.GetInterceptorProvider(request) != null);
+            }
+        }
+
+        /// <summary>
+        /// Creates a simple client handler with redirection and compression disabled.
+        /// </summary>
+        private HttpClientHandler CreateSimpleClientHandler()
+        {
+            var handler = new HttpClientHandler();
             if (handler.SupportsRedirectConfiguration)
             {
                 handler.AllowAutoRedirect = false;
             }
-
-            // If the framework supports automatic decompression and GZip is enabled, set automatic decompression.
-            if (handler.SupportsAutomaticDecompression && args.GZipEnabled)
+            if (handler.SupportsAutomaticDecompression)
             {
-                handler.AutomaticDecompression = System.Net.DecompressionMethods.GZip |
-                    System.Net.DecompressionMethods.Deflate;
+                handler.AutomaticDecompression = DecompressionMethods.None;
             }
-
-            Logger.Debug("Handler was created. SupportsRedirectConfiguration={0}, SupportsAutomaticDecompression={1}",
-                handler.SupportsRedirectConfiguration, handler.SupportsAutomaticDecompression);
-
             return handler;
         }
     }

--- a/Src/Support/Google.Apis.Core/Http/StreamInterceptionHandler.cs
+++ b/Src/Support/Google.Apis.Core/Http/StreamInterceptionHandler.cs
@@ -1,0 +1,122 @@
+﻿/*
+Copyright 2017 Google Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Google.Apis.Http
+{
+    /// <summary>
+    /// An HttpMessageHandler that (conditionally) intercepts response streams, allowing inline
+    /// stream processing. An interceptor provider function is fetched from each request via the
+    /// <see cref="ConfigurableMessageHandler.ResponseStreamInterceptorProviderKey"/> property;
+    /// if the property is not present on the request (or is null), the response will definitely not be
+    /// intercepted. If the property is present and non-null, the interceptor provider is called for
+    /// the response. This may return a null reference, indicating that interception isn't required, and
+    /// the response can be returned as-is. Otherwise, we use a <see cref="StreamReplacingHttpContent"/>
+    /// with an intercepting stream which passes all data read to the interceptor.
+    /// </summary>
+    internal sealed class StreamInterceptionHandler : DelegatingHandler
+    {
+        internal StreamInterceptionHandler(HttpMessageHandler handler) : base(handler)
+        {
+        }
+
+        /// <summary>
+        /// For each request, check whether we 
+        /// </summary>
+        /// <param name="request"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var responseTask = base.SendAsync(request, cancellationToken);
+            var provider = GetInterceptorProvider(request);
+            return provider == null ? responseTask : ReplaceAsync(responseTask, provider);
+        }
+
+        private async Task<HttpResponseMessage> ReplaceAsync(Task<HttpResponseMessage> responseTask, Func<HttpResponseMessage, StreamInterceptor> interceptorProvider)
+        {
+            var response = await responseTask.ConfigureAwait(false);
+            var interceptor = interceptorProvider(response);
+            if (interceptor != null)
+            {
+                response.Content = new StreamReplacingHttpContent(response.Content, stream => new InterceptingStream(stream, interceptor));
+            }
+            return response;
+        }
+
+        internal static Func<HttpResponseMessage, StreamInterceptor> GetInterceptorProvider(HttpRequestMessage request)
+        {
+            request.Properties.TryGetValue(ConfigurableMessageHandler.ResponseStreamInterceptorProviderKey, out var property);
+            // If anyone adds a property of the wrong type, just ignore it.
+            return property as Func<HttpResponseMessage, StreamInterceptor>;
+        }
+
+        private sealed class InterceptingStream : Stream
+        {
+            private readonly Stream _original;
+            private readonly StreamInterceptor _interceptor;
+
+            // We're a read-only stream, and we can't seek (as the interceptor will assume the content is read sequentially).
+            public override bool CanRead => true;
+            public override bool CanSeek => false;
+            public override bool CanWrite => false;
+
+            // Although we say we can't seek, we can return the length and current position.
+            // This may never be used, but is harmless to expose.
+            public override long Length => _original.Length;
+            public override long Position { get => _original.Position; set => throw new NotSupportedException(); }
+
+            internal InterceptingStream(Stream original, StreamInterceptor interceptor)
+            {
+                _original = original;
+                _interceptor = interceptor;
+            }
+
+            // Read methods which need to intercept the content.
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                // Perform the actual read, and then intercept just the content we read.
+                int ret = _original.Read(buffer, offset, count);
+                _interceptor(buffer, offset, ret);
+                return ret;
+            }
+
+            public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            {
+                // Perform the actual read, and then intercept just the content we read.
+                var ret = await _original.ReadAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
+                _interceptor(buffer, offset, ret);
+                return ret;
+            }
+
+            // Delegating methods
+            protected override void Dispose(bool disposing) => _original.Dispose();
+
+            // Almost certainly pointless, but harmless.
+            public override void Flush() => _original.Flush();
+
+            // Unsupported methods
+            public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+            public override void SetLength(long value) => throw new NotSupportedException();
+            public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        }
+    }
+}

--- a/Src/Support/Google.Apis.Core/Http/TwoWayDelegatingHandler.cs
+++ b/Src/Support/Google.Apis.Core/Http/TwoWayDelegatingHandler.cs
@@ -1,0 +1,73 @@
+﻿/*
+Copyright 2017 Google Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Google.Apis.Http
+{
+    /// <summary>
+    /// An HttpMessageHandler that delegates to one of two inner handlers based on a condition
+    /// checked on each request.
+    /// </summary>
+    internal sealed class TwoWayDelegatingHandler : DelegatingHandler
+    {
+        private readonly AccessibleDelegatingHandler _alternativeHandler;
+        private readonly Func<HttpRequestMessage, bool> _useAlternative;
+        private bool disposed = false;
+
+        internal TwoWayDelegatingHandler(HttpMessageHandler normalHandler, HttpMessageHandler alternativeHandler, Func<HttpRequestMessage, bool> useAlternative)
+            : base(normalHandler)
+        {
+            _alternativeHandler = new AccessibleDelegatingHandler(alternativeHandler);
+            _useAlternative = useAlternative;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+            _useAlternative(request) ? _alternativeHandler.InternalSendAsync(request, cancellationToken) : base.SendAsync(request, cancellationToken);
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && !disposed)
+            {
+                disposed = true;
+                try
+                {
+                    base.Dispose();
+                }
+                finally
+                {
+                    _alternativeHandler.Dispose();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Handler to wrap another, just so that we can effectively expose its SendAsync method.
+        /// </summary>
+        private sealed class AccessibleDelegatingHandler : DelegatingHandler
+        {
+            internal AccessibleDelegatingHandler(HttpMessageHandler innerHandler) : base(innerHandler)
+            {
+            }
+
+            internal Task<HttpResponseMessage> InternalSendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+                SendAsync(request, cancellationToken);
+        }
+    }
+}

--- a/Src/Support/Google.Apis.Tests/Apis/Http/GzipDeflateHandlerTest.cs
+++ b/Src/Support/Google.Apis.Tests/Apis/Http/GzipDeflateHandlerTest.cs
@@ -1,0 +1,136 @@
+﻿/*
+Copyright 2017 Google Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using Google.Apis.Http;
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Google.Apis.Tests.Apis.Http
+{
+    public class GzipDeflateHandlerTest
+    {
+        [Fact]
+        public async Task PlainTextContentLeftAlone()
+        {
+            var request = new HttpRequestMessage();
+            var response = new HttpResponseMessage
+            {
+                Content = new StringContent("Text")
+            };
+            await RunRequestAsync(request, response);
+            Assert.Equal("Text", await response.Content.ReadAsStringAsync());
+            AssertAcceptEncodingHeaders(request);
+        }
+
+        [Fact]
+        public async Task DeflateContentDecompressed()
+        {
+            var request = new HttpRequestMessage();
+            var response = new HttpResponseMessage
+            {
+                Content = CreateContent("Text", stream => new DeflateStream(stream, CompressionMode.Compress, true), "deflate"),
+            };
+            await RunRequestAsync(request, response);
+            Assert.Equal("Text", await response.Content.ReadAsStringAsync());
+            AssertAcceptEncodingHeaders(request);
+            AssertContentEncodings(response);
+        }
+
+        [Fact]
+        public async Task GzipContentDecompressed()
+        {
+            var request = new HttpRequestMessage();
+            var response = new HttpResponseMessage
+            {
+                Content = CreateContent("Text", stream => new GZipStream(stream, CompressionMode.Compress, true), "gzip"),
+            };
+            await RunRequestAsync(request, response);
+            Assert.Equal("Text", await response.Content.ReadAsStringAsync());
+            AssertAcceptEncodingHeaders(request);
+            AssertContentEncodings(response);
+        }
+
+        [Fact]
+        public async Task OnlyLastContentEncodingRelevant()
+        {
+            var request = new HttpRequestMessage();
+            var response = new HttpResponseMessage
+            {
+                Content = new StringContent("Text") { Headers = { ContentEncoding = { "gzip", "identity" } } }
+            };
+            await RunRequestAsync(request, response);
+            Assert.Equal("Text", await response.Content.ReadAsStringAsync());
+            AssertAcceptEncodingHeaders(request);
+            AssertContentEncodings(response, "gzip", "identity");
+        }
+
+        [Fact]
+        public async Task LastContentEncodingRemoved()
+        {
+            var request = new HttpRequestMessage();
+            var response = new HttpResponseMessage
+            {
+                Content = CreateContent("Text", stream => new GZipStream(stream, CompressionMode.Compress, true), "foo", "bar", "gzip"),
+            };
+            await RunRequestAsync(request, response);
+            Assert.Equal("Text", await response.Content.ReadAsStringAsync());
+            AssertAcceptEncodingHeaders(request);
+            AssertContentEncodings(response, "foo", "bar");
+        }
+
+        private StreamContent CreateContent(string text, Func<Stream, Stream> streamProvider, params string[] contentEncodings)
+        {
+            byte[] data = Encoding.UTF8.GetBytes(text);
+            var memoryStream = new MemoryStream();
+            using (var compressor = streamProvider(memoryStream))
+            {
+                compressor.Write(data, 0, data.Length);
+            }
+            memoryStream.Position = 0;
+            var content = new StreamContent(memoryStream);
+            foreach (var contentEncoding in contentEncodings)
+            {
+                content.Headers.ContentEncoding.Add(contentEncoding);
+            }
+            return content;
+        }
+
+        private void AssertAcceptEncodingHeaders(HttpRequestMessage request)
+        {
+            var acceptEncodings = request.Headers.AcceptEncoding.Select(h => h.Value);
+            Assert.Contains("gzip", acceptEncodings);
+            Assert.Contains("deflate", acceptEncodings);
+        }
+
+        private void AssertContentEncodings(HttpResponseMessage response, params string[] expectedEncodings)
+        {
+            var contentEncodings = response.Content.Headers.ContentEncoding;
+            Assert.Equal(expectedEncodings, contentEncodings);
+        }
+
+        private Task RunRequestAsync(HttpRequestMessage request, HttpResponseMessage response)
+        {
+            var handler = new GzipDeflateHandler(HandlerTestHelper.CreateHandler(response));
+            return HandlerTestHelper.ProcessRequestAsync(handler, request);
+        }        
+    }
+}

--- a/Src/Support/Google.Apis.Tests/Apis/Http/HandlerTestHelper.cs
+++ b/Src/Support/Google.Apis.Tests/Apis/Http/HandlerTestHelper.cs
@@ -1,0 +1,69 @@
+﻿/*
+Copyright 2017 Google Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Google.Apis.Tests.Apis.Http
+{
+    /// <summary>
+    /// Helper for tests for HttpHandlers.
+    /// </summary>
+    internal static class HandlerTestHelper
+    {
+        /// <summary>
+        /// Processes the given request in the given handler. This basically
+        /// works around the annoyance that SendAsync is protected.
+        /// </summary>
+        internal static Task<HttpResponseMessage> ProcessRequestAsync(
+            HttpMessageHandler handler, HttpRequestMessage request, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var trampoline = new TestHandler(handler);
+            return trampoline.ExposedSendAync(request, cancellationToken);
+        }
+
+        /// <summary>
+        /// Creates a handler that will return the given response message.
+        /// </summary>
+        internal static HttpMessageHandler CreateHandler(HttpResponseMessage response) =>
+            new SingleResponseHandler(response);
+
+        private class TestHandler : DelegatingHandler
+        {
+            internal TestHandler(HttpMessageHandler handler) : base(handler)
+            {
+            }
+
+            internal Task<HttpResponseMessage> ExposedSendAync(
+                HttpRequestMessage request, CancellationToken cancellationToken) =>
+                base.SendAsync(request, cancellationToken);
+        }
+
+        private class SingleResponseHandler : HttpMessageHandler
+        {
+            private readonly HttpResponseMessage _response;
+
+            internal SingleResponseHandler(HttpResponseMessage response)
+            {
+                _response = response;
+            }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+                => Task.FromResult(_response);
+        }
+    }
+}

--- a/Src/Support/Google.Apis/Download/MediaDownloader.cs
+++ b/Src/Support/Google.Apis/Download/MediaDownloader.cs
@@ -25,6 +25,7 @@ using Google.Apis.Media;
 using Google.Apis.Services;
 using Google.Apis.Util;
 using System.Net.Http.Headers;
+using Google.Apis.Http;
 
 namespace Google.Apis.Download
 {
@@ -73,6 +74,13 @@ namespace Google.Apis.Download
         /// of the requested media.
         /// </summary>
         public RangeHeaderValue Range { get; set; }
+
+        /// <summary>
+        /// A provider for response stream interceptors. Each time a response is produced, the provider
+        /// is called, and can return <c>null</c> if interception is not required, or an interceptor for
+        /// that response. The provider itself should not read the response's content stream, but can check headers.
+        /// </summary>
+        public Func<HttpResponseMessage, StreamInterceptor> ResponseStreamInterceptorProvider { get; set; }
 
         #region Progress
 
@@ -258,6 +266,10 @@ namespace Google.Apis.Download
 
             var request = new HttpRequestMessage(HttpMethod.Get, uri.ToString());
             request.Headers.Range = Range;
+            if (ResponseStreamInterceptorProvider != null)
+            {
+                request.Properties[ConfigurableMessageHandler.ResponseStreamInterceptorProviderKey] = ResponseStreamInterceptorProvider;
+            }
             ModifyRequest?.Invoke(request);
 
             // Number of bytes sent to the caller's stream.

--- a/third_party/System.Net.Http/DecompressionHandler.cs
+++ b/third_party/System.Net.Http/DecompressionHandler.cs
@@ -1,0 +1,168 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace System.Net.Http
+{
+    internal sealed class DecompressionHandler : HttpMessageHandler
+    {
+        private readonly HttpMessageHandler _innerHandler;
+        private readonly DecompressionMethods _decompressionMethods;
+
+        private const string s_gzip = "gzip";
+        private const string s_deflate = "deflate";
+        private static StringWithQualityHeaderValue s_gzipHeaderValue = new StringWithQualityHeaderValue(s_gzip);
+        private static StringWithQualityHeaderValue s_deflateHeaderValue = new StringWithQualityHeaderValue(s_deflate);
+
+        public DecompressionHandler(DecompressionMethods decompressionMethods, HttpMessageHandler innerHandler)
+        {
+            _innerHandler = innerHandler ?? throw new ArgumentNullException(nameof(innerHandler));
+            if (decompressionMethods == DecompressionMethods.None)
+            {
+                throw new ArgumentOutOfRangeException(nameof(decompressionMethods));
+            }
+            _decompressionMethods = decompressionMethods;
+        }
+
+        internal bool GZipEnabled => (_decompressionMethods & DecompressionMethods.GZip) != 0;
+        internal bool DeflateEnabled => (_decompressionMethods & DecompressionMethods.Deflate) != 0;
+
+        protected internal override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (GZipEnabled)
+            {
+                request.Headers.AcceptEncoding.Add(s_gzipHeaderValue);
+            }
+            if (DeflateEnabled)
+            {
+                request.Headers.AcceptEncoding.Add(s_deflateHeaderValue);
+            }
+
+            HttpResponseMessage response = await _innerHandler.SendAsync(request, cancellationToken).ConfigureAwait(false);
+
+            ICollection<string> contentEncodings = response.Content.Headers.ContentEncoding;
+            if (contentEncodings.Count > 0)
+            {
+                string last = null;
+                foreach (string encoding in contentEncodings)
+                {
+                    last = encoding;
+                }
+
+                if (GZipEnabled && last == s_gzip)
+                {
+                    response.Content = new GZipDecompressedContent(response.Content);
+                }
+                else if (DeflateEnabled && last == s_deflate)
+                {
+                    response.Content = new DeflateDecompressedContent(response.Content);
+                }
+            }
+
+            return response;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _innerHandler.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+
+        private abstract class DecompressedContent : HttpContent
+        {
+            HttpContent _originalContent;
+            bool _contentConsumed;
+
+            public DecompressedContent(HttpContent originalContent)
+            {
+                _originalContent = originalContent;
+                _contentConsumed = false;
+
+                // Copy original response headers, but with the following changes:
+                //   Content-Length is removed, since it no longer applies to the decompressed content
+                //   The last Content-Encoding is removed, since we are processing that here.
+                Headers.AddHeaders(originalContent.Headers);
+                Headers.ContentLength = null;
+                Headers.ContentEncoding.Clear();
+                string prevEncoding = null;
+                foreach (string encoding in originalContent.Headers.ContentEncoding)
+                {
+                    if (prevEncoding != null)
+                    {
+                        Headers.ContentEncoding.Add(prevEncoding);
+                    }
+                    prevEncoding = encoding;
+                }
+            }
+
+            protected abstract Stream GetDecompressedStream(Stream originalStream);
+
+            protected override async Task SerializeToStreamAsync(Stream stream, TransportContext context)
+            {
+                using (Stream decompressedStream = await CreateContentReadStreamAsync().ConfigureAwait(false))
+                {
+                    await decompressedStream.CopyToAsync(stream).ConfigureAwait(false);
+                }
+            }
+
+            protected override async Task<Stream> CreateContentReadStreamAsync()
+            {
+                if (_contentConsumed)
+                {
+                    throw new InvalidOperationException(SR.net_http_content_stream_already_read);
+                }
+
+                _contentConsumed = true;
+
+                Stream originalStream = _originalContent.TryReadAsStream() ?? await _originalContent.ReadAsStreamAsync().ConfigureAwait(false);
+                return GetDecompressedStream(originalStream);
+            }
+
+            protected internal override bool TryComputeLength(out long length)
+            {
+                length = 0;
+                return false;
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    _originalContent.Dispose();
+                }
+                base.Dispose(disposing);
+            }
+        }
+
+        private sealed class GZipDecompressedContent : DecompressedContent
+        {
+            public GZipDecompressedContent(HttpContent originalContent)
+                : base(originalContent)
+            { }
+
+            protected override Stream GetDecompressedStream(Stream originalStream) =>
+                new GZipStream(originalStream, CompressionMode.Decompress);
+        }
+
+        private sealed class DeflateDecompressedContent : DecompressedContent
+        {
+            public DeflateDecompressedContent(HttpContent originalContent)
+                : base(originalContent)
+            { }
+
+            protected override Stream GetDecompressedStream(Stream originalStream) =>
+                new DeflateStream(originalStream, CompressionMode.Decompress);
+        }
+    }
+}

--- a/third_party/System.Net.Http/GzipDeflateHandler.cs
+++ b/third_party/System.Net.Http/GzipDeflateHandler.cs
@@ -1,0 +1,88 @@
+/*
+Copyright 2017 Google Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Google.Apis.Http
+{
+    /// <summary>
+    /// An HttpMessageHandler that performs decompression for Deflate and Gzip content.
+    /// </summary>
+    internal sealed class GzipDeflateHandler : DelegatingHandler
+    {
+        private const string GzipEncoding = "gzip";
+        private const string DeflateEncoding = "deflate";
+
+        private static readonly StringWithQualityHeaderValue s_gzipAcceptHeader =
+            new StringWithQualityHeaderValue(GzipEncoding);
+        private static readonly StringWithQualityHeaderValue s_deflateAcceptHeader =
+            new StringWithQualityHeaderValue(DeflateEncoding);
+        
+        private static readonly Func<Stream, Stream> s_gzipReplacement =
+            original => new GZipStream(original, CompressionMode.Decompress);
+
+        private static readonly Func<Stream, Stream> s_deflateReplacement =
+            original => new DeflateStream(original, CompressionMode.Decompress);
+        
+        internal GzipDeflateHandler(HttpMessageHandler innerHandler) : base(innerHandler)
+        {
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            request.Headers.AcceptEncoding.Add(s_gzipAcceptHeader);
+            request.Headers.AcceptEncoding.Add(s_deflateAcceptHeader);
+
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            var originalContent = response.Content;
+            var lastContentEncoding = originalContent.Headers.ContentEncoding.LastOrDefault();
+
+            Func<Stream, Stream> replacement =
+                lastContentEncoding == GzipEncoding ? s_gzipReplacement
+                : lastContentEncoding == DeflateEncoding ? s_deflateReplacement
+                : null;
+
+            if (replacement != null)
+            {
+                response.Content = new StreamReplacingHttpContent(originalContent, replacement);
+                var headers = response.Content.Headers;
+                // We don't know what the content length will be any more.
+                headers.ContentLength = null;
+                // Remove the last encoding (because we're handling it).
+                // This is slightly ugly due to the API offered by ICollection<T>.
+                headers.ContentEncoding.Clear();
+                string previous = null;
+                foreach (var encoding in originalContent.Headers.ContentEncoding)
+                {
+                    if (previous != null)
+                    {
+                        headers.ContentEncoding.Add(previous);
+                    }
+                    previous = encoding;
+                }
+            }
+            return response;
+        }
+    }
+}

--- a/third_party/System.Net.Http/LICENSE.TXT
+++ b/third_party/System.Net.Http/LICENSE.TXT
@@ -1,0 +1,23 @@
+The MIT License (MIT)
+
+Copyright (c) .NET Foundation and Contributors
+
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/third_party/System.Net.Http/METADATA
+++ b/third_party/System.Net.Http/METADATA
@@ -1,0 +1,24 @@
+name: "System.Net.Http"
+description:
+    "System.Net.Http contains HTTP client code. This directory "
+    "contains a derived work of the original decompression handler "
+    "that forms part of System.Net.Http; it is not a complete copy "
+    "of System.Net.Http."
+
+third_party {
+  url {
+    type: HOMEPAGE
+    value: "https://www.dotnetfoundation.org/"
+  }
+  url {
+    type: GIT
+    value: "https://github.com/dotnet/corefx"
+  }
+  version: "3c17c2251b4bda98273e57ef153cc9bc267805c8"
+  last_upgrade_date { year: 2017 month: 12 day: 7 }
+  license_type: NOTICE
+  local_modifications:
+      "The original file is DecompressionHandler.cs from "
+      "src/System.Net.Http/src/System/Net/Http/Managed/DecompressionHandler.cs"
+      " relative to the source root. See README.md for more details."
+}

--- a/third_party/System.Net.Http/README.md
+++ b/third_party/System.Net.Http/README.md
@@ -1,0 +1,10 @@
+The original code in DecompressionHandler.cs is the MIT-licensed code from
+https://github.com/dotnet/corefx. This file is not built within this
+repository.
+
+Instead, the derived works in the Apache-licensed
+StreamReplacingHttpContent.cs and GzipDeflateHandler.cs are used. (This
+separation allows the reuse of stream replacement in other scenarios.)
+These source files are present in this directory to indicate that they are
+derived from DecompressionHandler. These derived works are included in the
+Google.Apis.Core assembly when built.

--- a/third_party/System.Net.Http/StreamReplacingHttpContent.cs
+++ b/third_party/System.Net.Http/StreamReplacingHttpContent.cs
@@ -1,0 +1,75 @@
+/*
+Copyright 2017 Google Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Google.Apis.Http
+{
+    /// <summary>
+    /// An HttpContent based on an existing one, but allowing the stream to be replaced.
+    /// This is similar to StreamContent, but it defers the stream creation until it's requested by the client.
+    /// (An alternative would be to use StreamContent with a custom stream that only retrieved the stream when
+    /// first used.) Headers are copied from the original content.
+    /// </summary>
+    internal sealed class StreamReplacingHttpContent : HttpContent
+    {
+        private readonly HttpContent _originalContent;
+        private readonly Func<Stream, Stream> _replacement;
+        private bool _streamCreated = false;
+
+        internal StreamReplacingHttpContent(HttpContent originalContent, Func<Stream, Stream> replacement)
+        {
+            _originalContent = originalContent;
+            _replacement = replacement;
+
+            foreach (var header in originalContent.Headers)
+            {
+                Headers.Add(header.Key, header.Value);
+            }
+        }
+
+        // Unfortunately we can't delegate this to the original content even if we know the length hasn't changed,
+        // as TryComputeLength is protected.
+        protected override bool TryComputeLength(out long length)
+        {
+            length = 0;
+            return false;
+        }
+
+        protected override async Task<Stream> CreateContentReadStreamAsync()
+        {
+            if (_streamCreated)
+            {
+                throw new InvalidOperationException("Cannot read content stream more than once");
+            }
+            _streamCreated = true;
+            var originalStream = await _originalContent.ReadAsStreamAsync().ConfigureAwait(false);
+            return _replacement(originalStream);
+        }
+
+        protected override async Task SerializeToStreamAsync(Stream stream, TransportContext context)
+        {
+            using (Stream contentStream = await CreateContentReadStreamAsync().ConfigureAwait(false))
+            {
+                await contentStream.CopyToAsync(stream).ConfigureAwait(false);
+            }
+        }
+    }
+}


### PR DESCRIPTION
To validate Storage hashes, we need to be able to intercept the HTTP response data before it is decompressed if the Content-Encoding is gzip. (The hash header indicates the hash of the compressed content.)

The built-in decompression in HttpClient happens too early for us, so we need to add our own decompressing HTTP handler. That's based on .NET Foundation code; the first commit of this PR adds both the original and derived works in third_party. This requires special review.

The second commit uses the decompression handler, and adds a stream interception handler which is only applied if a particular property is in the request message; this allows reasonably fine-grained control over when interception is applied.

Decompression is performed with the built-in HttpClientHandler where a) it's available; b) interception isn't required. This requires another custom handler which can delegate to one of two other handlers based on the request.

As well as providing interception, this PR fixes two other issues:

- If decompression is requested, we now provide it whether or not HttpClient supports it
- If decompression is *not* requested, we don't provide it even if it's on by default. Fixes #1110.