### PR TITLE
(Not for submission) Introduce a TokenRefreshManager to perform token refreshes

### DIFF
--- a/Src/Support/Google.Apis.Auth.Tests/OAuth2/Responses/TokenResponseTests.cs
+++ b/Src/Support/Google.Apis.Auth.Tests/OAuth2/Responses/TokenResponseTests.cs
@@ -65,6 +65,8 @@ namespace Google.Apis.Auth.Tests.OAuth2.Responses
                 UtcNow = newNow
             };
 
+            const int ExpectedRefreshTimeSeconds = 6 * 60;
+
             // Issued not set.
             var response = new TokenResponse();
             Assert.True(response.IsExpired(mockClock));
@@ -79,19 +81,19 @@ namespace Google.Apis.Auth.Tests.OAuth2.Responses
             response = new TokenResponse() { AccessToken = "a", ExpiresInSeconds = 100, IssuedUtc = issued };
             Assert.True(response.IsExpired(mockClock));
 
-            response = new TokenResponse() { AccessToken = "a", ExpiresInSeconds = 100 + 5 * 60 - 2, IssuedUtc = issued };
+            response = new TokenResponse() { AccessToken = "a", ExpiresInSeconds = 100 + ExpectedRefreshTimeSeconds - 2, IssuedUtc = issued };
             Assert.True(response.IsExpired(mockClock));
 
-            response = new TokenResponse() { AccessToken = "a", ExpiresInSeconds = 100 + 5 * 60 - 1, IssuedUtc = issued };
+            response = new TokenResponse() { AccessToken = "a", ExpiresInSeconds = 100 + ExpectedRefreshTimeSeconds - 1, IssuedUtc = issued };
             Assert.True(response.IsExpired(mockClock));
 
-            response = new TokenResponse() { AccessToken = "a", ExpiresInSeconds = 100 + 5 * 60, IssuedUtc = issued };
+            response = new TokenResponse() { AccessToken = "a", ExpiresInSeconds = 100 + ExpectedRefreshTimeSeconds, IssuedUtc = issued };
             Assert.True(response.IsExpired(mockClock));
 
-            response = new TokenResponse() { AccessToken = "a", ExpiresInSeconds = 100 + 5 * 60 + 1, IssuedUtc = issued };
+            response = new TokenResponse() { AccessToken = "a", ExpiresInSeconds = 100 + ExpectedRefreshTimeSeconds + 1, IssuedUtc = issued };
             Assert.False(response.IsExpired(mockClock));
 
-            response = new TokenResponse() { AccessToken = "a", ExpiresInSeconds = 100 + 5 * 60 + 2, IssuedUtc = issued };
+            response = new TokenResponse() { AccessToken = "a", ExpiresInSeconds = 100 + ExpectedRefreshTimeSeconds + 2, IssuedUtc = issued };
             Assert.False(response.IsExpired(mockClock));
         }
 

--- a/Src/Support/Google.Apis.Auth/OAuth2/ServiceCredential.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/ServiceCredential.cs
@@ -190,7 +190,7 @@ namespace Google.Apis.Auth.OAuth2
         /// </summary>
         public virtual Task<string> GetAccessTokenForRequestAsync(string authUri = null,
             CancellationToken cancellationToken = default(CancellationToken)) =>
-            _refreshManager.GetAccessTokenForRequestAsync(authUri, cancellationToken);
+            _refreshManager.GetAccessTokenForRequestAsync(cancellationToken);
 
         #endregion
 

--- a/Src/Support/Google.Apis.Auth/OAuth2/ServiceCredential.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/ServiceCredential.cs
@@ -88,55 +88,33 @@ namespace Google.Apis.Auth.OAuth2
             }
         }
 
-        #region Readonly fields
-
-        private readonly string tokenServerUrl;
-        private readonly IClock clock;
-        private readonly IAccessMethod accessMethod;
-        private readonly ConfigurableHttpClient httpClient;
-
-        #endregion
-
         /// <summary>Gets the token server URL.</summary>
-        public string TokenServerUrl { get { return tokenServerUrl; } }
+        public string TokenServerUrl { get; }
 
         /// <summary>Gets the clock used to refresh the token if it expires.</summary>
-        public IClock Clock { get { return clock; } }
+        public IClock Clock { get; }
 
         /// <summary>Gets the method for presenting the access token to the resource server.</summary>
-        public IAccessMethod AccessMethod { get { return accessMethod; } }
+        public IAccessMethod AccessMethod { get; }
 
         /// <summary>Gets the HTTP client used to make authentication requests to the server.</summary>
-        public ConfigurableHttpClient HttpClient { get { return httpClient; } }
+        public ConfigurableHttpClient HttpClient { get; }
 
-        private TokenResponse token;
-        private object lockObject = new object();
+        private readonly TokenRefreshManager _refreshManager;
 
         /// <summary>Gets the token response which contains the access token.</summary>
         public TokenResponse Token
         {
-            get
-            {
-                lock (lockObject)
-                {
-                    return token;
-                }
-            }
-            protected set
-            {
-                lock (lockObject)
-                {
-                    token = value;
-                }
-            }
+            get => _refreshManager.Token;
+            set => _refreshManager.Token = value;
         }
 
         /// <summary>Constructs a new service account credential using the given initializer.</summary>
         public ServiceCredential(Initializer initializer)
         {
-            tokenServerUrl = initializer.TokenServerUrl;
-            accessMethod = initializer.AccessMethod.ThrowIfNull("initializer.AccessMethod");
-            clock = initializer.Clock.ThrowIfNull("initializer.Clock");
+            TokenServerUrl = initializer.TokenServerUrl;
+            AccessMethod = initializer.AccessMethod.ThrowIfNull("initializer.AccessMethod");
+            Clock = initializer.Clock.ThrowIfNull("initializer.Clock");
 
             // Set the HTTP client.
             var httpArgs = new CreateHttpClientArgs();
@@ -148,7 +126,8 @@ namespace Google.Apis.Auth.OAuth2
                     new ExponentialBackOffInitializer(initializer.DefaultExponentialBackOffPolicy,
                         () => new BackOffHandler(new ExponentialBackOff())));
             }
-            httpClient = (initializer.HttpClientFactory ?? new HttpClientFactory()).CreateHttpClient(httpArgs);
+            HttpClient = (initializer.HttpClientFactory ?? new HttpClientFactory()).CreateHttpClient(httpArgs);
+            _refreshManager = new TokenRefreshManager(RequestAccessTokenAsync, Clock, Logger);
         }
 
         #region IConfigurableHttpClientInitializer
@@ -206,23 +185,12 @@ namespace Google.Apis.Auth.OAuth2
         #region ITokenAccess implementation
 
         /// <summary>
-        /// Gets an access token to authorize a request. If the existing token has expired, try to refresh it first.
+        /// Gets an access token to authorize a request. If the existing token expires soon, try to refresh it first.
         /// <seealso cref="ITokenAccess.GetAccessTokenForRequestAsync"/>
         /// </summary>
-        public virtual async Task<string> GetAccessTokenForRequestAsync(string authUri = null,
-            CancellationToken cancellationToken = default(CancellationToken))
-        {
-            if (Token == null || Token.IsExpired(Clock))
-            {
-                Logger.Debug("Token has expired, trying to get a new one.");
-                if (!await RequestAccessTokenAsync(cancellationToken).ConfigureAwait(false))
-                {
-                    throw new InvalidOperationException("The access token has expired but we can't refresh it");
-                }
-                Logger.Info("New access token was received successfully");
-            }
-            return Token.AccessToken;
-        }
+        public virtual Task<string> GetAccessTokenForRequestAsync(string authUri = null,
+            CancellationToken cancellationToken = default(CancellationToken)) =>
+            _refreshManager.GetAccessTokenForRequestAsync(authUri, cancellationToken);
 
         #endregion
 

--- a/Src/Support/Google.Apis.Auth/OAuth2/TokenRefreshManager.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/TokenRefreshManager.cs
@@ -1,0 +1,170 @@
+﻿/*
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using Google.Apis.Auth.OAuth2.Responses;
+using Google.Apis.Logging;
+using Google.Apis.Util;
+using System;
+using System.Linq;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Google.Apis.Auth.OAuth2
+{
+    /// <summary>
+    /// Encapsulation of token refresh behaviour. This isn't entirely how we'd design the code now (in terms of the
+    /// callback in particular) but it fits in with the exposed API surface of ServiceCredential and UserCredential.
+    /// </summary>
+    internal sealed class TokenRefreshManager
+    {
+        // Immutable state
+        private readonly object _lock = new object();
+        private readonly IClock _clock;
+        private readonly ILogger _logger;
+        private readonly Func<CancellationToken, Task<bool>> _refreshAction;
+
+        // Mutable state, guarded with _lock.
+        private TokenResponse _token;
+        private Task<TokenResponse> _refreshTask;
+
+        /// <summary>
+        /// Creates a manager which executes the given refresh action when required.
+        /// </summary>
+        /// <param name="refreshAction">The refresh action which will populate the Token property when successful.</param>
+        /// <param name="clock">The clock to consult for timeouts.</param>
+        /// <param name="logger">The logger to use to record refreshes.</param>
+        internal TokenRefreshManager(Func<CancellationToken, Task<bool>> refreshAction, IClock clock, ILogger logger)
+        {
+            _refreshAction = refreshAction;
+            _clock = clock;
+            _logger = logger;
+        }
+
+        internal TokenResponse Token
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    return _token;
+                }
+            }
+            // The token may be set due to operations other than GetAccessTokenForRequestAsync, but we don't need to
+            // null out _refreshTask if so; it will be 
+            set
+            {
+                lock (_lock)
+                {
+                    _token = value;
+                }
+            }
+        }
+
+        internal async Task<string> GetAccessTokenForRequestAsync(string authUri, CancellationToken cancellationToken)
+        {
+            TokenResponse currentToken;
+            Task<TokenResponse> currentRefreshTask;
+            lock (_lock)
+            {
+                currentToken = _token;
+                currentRefreshTask = _refreshTask;
+            }
+            // Note: IsExpired is really "should be refreshed".
+            if (currentToken == null || currentToken.IsExpired(_clock))
+            {
+                // Start a refresh if nothing else is already refreshing the token.
+                // It's possible to end up with multiple requests here (if another thread started a task while
+                // we were checking for expiry) but that's a small window, and harmless so long as there aren't *too*
+                // many requests.
+                if (currentRefreshTask == null)
+                {
+                    currentRefreshTask = RefreshTokenAsync();
+                    lock (_lock)
+                    {
+                        _refreshTask = currentRefreshTask;
+                    }
+                }
+                // If the current token is still valid for a while, we can use it anyway. Otherwise,
+                // we need to wait for our refresh task to complete.
+                if (currentToken == null || currentToken.IsEffectivelyExpired(_clock))
+                {
+                    Task<TokenResponse> taskToAwait = currentRefreshTask;
+                    if (cancellationToken.CanBeCanceled)
+                    {
+                        // Reasonably simple way of creating a task that can be cancelled, based on another task.
+                        // (It would be nice if this were simpler.)
+                        taskToAwait = taskToAwait.ContinueWith(
+                            task => ResultWithUnwrappedExceptions(task),
+                            cancellationToken,
+                            TaskContinuationOptions.None,
+                            TaskScheduler.Default);
+                    }
+                    currentToken = await taskToAwait.ConfigureAwait(false);
+                }
+            }
+            return currentToken.AccessToken;
+        }
+
+
+        private async Task<TokenResponse> RefreshTokenAsync()
+        {
+            _logger.Debug("Token has expired, trying to get a new one.");
+            try
+            {
+                // TODO: Is using a cancellation task of "none" definitely appropriate? If this hangs forever,
+                // all tasks waiting for it will also hang forever, unless they have cancellation tokens.
+                var successTask = await _refreshAction(CancellationToken.None).ConfigureAwait(false);
+                if (successTask)
+                {
+                    _logger.Info("New access token was received successfully");
+                    return Token;
+                }
+                else
+                {
+                    throw new InvalidOperationException("The access token has expired could not be refreshed");
+                }
+            }
+            finally
+            {
+                // If the task completed successfully, Token will have been set.
+                // Otherwise, we'll want to start a new refresh task next time we're asked for a token.
+                lock (_lock)
+                {
+                    _refreshTask = null;
+                }
+            }
+        }
+
+        // Helper method used in the continuation when trying to create a cancellable task.
+        private static T ResultWithUnwrappedExceptions<T>(Task<T> task)
+        {
+            try
+            {
+                task.Wait();
+            }
+            catch (AggregateException e)
+            {
+                // Unwrap the first exception, a bit like await would.
+                // It's very unlikely that we'd ever see an AggregateException without an inner exceptions,
+                // but let's handle it relatively gracefully.
+                // Using ExceptionDispatchInfo to keep the original exception stack trace.
+                ExceptionDispatchInfo.Capture(e.InnerExceptions.FirstOrDefault() ?? e).Throw();
+            }
+            return task.Result;
+        }
+    }
+}

--- a/Src/Support/Google.Apis.Auth/OAuth2/TokenRefreshManager.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/TokenRefreshManager.cs
@@ -74,7 +74,7 @@ namespace Google.Apis.Auth.OAuth2
             }
         }
 
-        internal async Task<string> GetAccessTokenForRequestAsync(string authUri, CancellationToken cancellationToken)
+        internal async Task<string> GetAccessTokenForRequestAsync(CancellationToken cancellationToken)
         {
             TokenResponse currentToken;
             Task<TokenResponse> currentRefreshTask;

--- a/Src/Support/Google.Apis.Auth/OAuth2/UserCredential.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/UserCredential.cs
@@ -36,42 +36,20 @@ namespace Google.Apis.Auth.OAuth2
         /// <summary>Logger for this class.</summary>
         protected static readonly ILogger Logger = ApplicationContext.Logger.ForType<UserCredential>();
 
-        private TokenResponse token;
-        private object lockObject = new object();
-
         /// <summary>Gets or sets the token response which contains the access token.</summary>
         public TokenResponse Token
         {
-            get
-            {
-                lock (lockObject)
-                {
-                    return token;
-                }
-            }
-            set
-            {
-                lock (lockObject)
-                {
-                    token = value;
-                }
-            }
+            get => _refreshManager.Token;
+            set => _refreshManager.Token = value;
         }
 
         /// <summary>Gets the authorization code flow.</summary>
-        public IAuthorizationCodeFlow Flow
-        {
-            get { return flow; }
-        }
+        public IAuthorizationCodeFlow Flow { get; }
 
         /// <summary>Gets the user identity.</summary>
-        public string UserId
-        {
-            get { return userId; }
-        }
+        public string UserId { get; }
 
-        private readonly IAuthorizationCodeFlow flow;
-        private readonly string userId;
+        private readonly TokenRefreshManager _refreshManager;
 
         /// <summary>Constructs a new credential instance.</summary>
         /// <param name="flow">Authorization code flow.</param>
@@ -79,9 +57,10 @@ namespace Google.Apis.Auth.OAuth2
         /// <param name="token">An initial token for the user.</param>
         public UserCredential(IAuthorizationCodeFlow flow, string userId, TokenResponse token)
         {
-            this.flow = flow;
-            this.userId = userId;
-            this.token = token;
+            this.Flow = flow;
+            this.UserId = userId;
+            _refreshManager = new TokenRefreshManager(RefreshTokenAsync, flow.Clock, Logger);
+            this.Token = token;
         }
 
         #region IHttpExecuteInterceptor
@@ -94,7 +73,7 @@ namespace Google.Apis.Auth.OAuth2
         public async Task InterceptAsync(HttpRequestMessage request, CancellationToken taskCancellationToken)
         {
             var accessToken = await GetAccessTokenForRequestAsync(request.RequestUri.AbsoluteUri, taskCancellationToken).ConfigureAwait(false);
-            flow.AccessMethod.Intercept(request, Token.AccessToken);
+            Flow.AccessMethod.Intercept(request, Token.AccessToken);
         }
 
         #endregion
@@ -107,7 +86,7 @@ namespace Google.Apis.Auth.OAuth2
             // TODO(peleyal): check WWW-Authenticate header.
             if (args.Response.StatusCode == HttpStatusCode.Unauthorized)
             {
-                return !Object.Equals(Token.AccessToken, flow.AccessMethod.GetAccessToken(args.Request))
+                return !Object.Equals(Token.AccessToken, Flow.AccessMethod.GetAccessToken(args.Request))
                     || await RefreshTokenAsync(args.CancellationToken).ConfigureAwait(false);
             }
 
@@ -128,21 +107,10 @@ namespace Google.Apis.Auth.OAuth2
         #endregion
 
         #region ITokenAccess implementation
-
-        /// <inheritdoc/>
-        public virtual async Task<string> GetAccessTokenForRequestAsync(string authUri = null, CancellationToken cancellationToken = default(CancellationToken))
-        {
-            if (Token.IsExpired(flow.Clock))
-            {
-                Logger.Debug("Token has expired, trying to refresh it.");
-                if (!await RefreshTokenAsync(cancellationToken).ConfigureAwait(false))
-                {
-                    throw new InvalidOperationException("The access token has expired but we can't refresh it");
-                }
-            }
-            return token.AccessToken;
-        }
-
+        /// <inheritdoc />
+        public virtual Task<string> GetAccessTokenForRequestAsync(string authUri = null,
+            CancellationToken cancellationToken = default(CancellationToken)) =>
+            _refreshManager.GetAccessTokenForRequestAsync(authUri, cancellationToken);    
         #endregion
 
         /// <summary>
@@ -162,7 +130,7 @@ namespace Google.Apis.Auth.OAuth2
 
             // It's possible that two concurrent calls will be made to refresh the token, in that case the last one 
             // will win.
-            var newToken = await flow.RefreshTokenAsync(userId, Token.RefreshToken, taskCancellationToken)
+            var newToken = await Flow.RefreshTokenAsync(UserId, Token.RefreshToken, taskCancellationToken)
                 .ConfigureAwait(false);
 
             Logger.Info("Access token was refreshed successfully");
@@ -190,7 +158,7 @@ namespace Google.Apis.Auth.OAuth2
                 return false;
             }
 
-            await flow.RevokeTokenAsync(userId, Token.AccessToken, taskCancellationToken).ConfigureAwait(false);
+            await Flow.RevokeTokenAsync(UserId, Token.AccessToken, taskCancellationToken).ConfigureAwait(false);
             Logger.Info("Access token was revoked successfully");
             // We don't set the token to null, cause we want that the next request (without reauthorizing) will fail).
             return true;

--- a/Src/Support/Google.Apis.Auth/OAuth2/UserCredential.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/UserCredential.cs
@@ -110,7 +110,7 @@ namespace Google.Apis.Auth.OAuth2
         /// <inheritdoc />
         public virtual Task<string> GetAccessTokenForRequestAsync(string authUri = null,
             CancellationToken cancellationToken = default(CancellationToken)) =>
-            _refreshManager.GetAccessTokenForRequestAsync(authUri, cancellationToken);    
+            _refreshManager.GetAccessTokenForRequestAsync(cancellationToken);    
         #endregion
 
         /// <summary>


### PR DESCRIPTION
The production code is probably about right, but careful review is required. If the design is seen as being okay, I'll write unit tests.

---

This is then used by ServiceCredential and UserCredential, which effectively handle token refreshes the same way. In particular, neither of them use the authUri parameter by default. (ServiceAccountCredential does, by overriding GetAccessTokenForRequest, but that's okay as it will only delegate when the auth URI doesn't matter.)

The TokenRefreshManager avoids multiple concurrent requests by remembering an in-flight task and using that for subsequent requests.

Additionally, it reduces latency by starting a refresh task even when the existing token is still valid, 6 minutes before expiry. We deem a token that expires in 5 minutes to be too close to expiry to use, so as long as there's a reasonable stream of requests and the refresh is short, we should always be able to use a cached access token.