### PR TITLE
Document packages as deprecated when there a Cloud package exists

### DIFF
--- a/ClientGenerator/src/googleapis/codegen/languages/csharp/default/features.json
+++ b/ClientGenerator/src/googleapis/codegen/languages/csharp/default/features.json
@@ -4,5 +4,21 @@
   "releaseVersion": "1.33.0", "comment1": "Version of generated package.",
   "currentSupportVersion": "1.33.0", "comment2": "Version of support library upon which to depend.",
   "pclSupportVersion": "1.25.0", "comment3": "Version of PCL support library.",
-  "net40SupportVersion": "1.10.0", "comment4": "Version of net40 support library."
+  "net40SupportVersion": "1.10.0", "comment4": "Version of net40 support library.",
+
+  "clouds_comment": "Defines the map of Google.Cloud packages that superseed Google.Apis packages",
+  "clouds": {
+    "Google.Apis.Bigquery.v2": "Google.Cloud.BigQuery.V2",
+    "Google.Apis.Datastore.v1": "Google.Cloud.Datastore.V1",
+    "Google.Apis.CloudNaturalLanguage.v1": "Google.Cloud.Language.V1",
+    "Google.Apis.Logging.v2": "Google.Cloud.Logging.V2",
+    "Google.Apis.Monitoring.v3": "Google.Cloud.Monitoring.V3",
+    "Google.Apis.Spanner.v1": "Google.Cloud.Spanner.Data",
+    "Google.Apis.Speech.v1": "Google.Cloud.Speech.V1",
+    "Google.Apis.Storage.v1": "Google.Cloud.Storage.V1",
+    "Google.Apis.Cloudtrace.v1": "Google.Cloud.Trace.V1",
+    "Google.Apis.Translate.v2": "Google.Cloud.Translation.V2",
+    "Google.Apis.CloudVideoIntelligence.v1": "Google.Cloud.VideoIntelligence.V1",
+    "Google.Apis.Vision.v1": "Google.Cloud.Vision.V1"
+  }
 }

--- a/ClientGenerator/src/googleapis/codegen/languages/csharp/default/templates/___package_name___/___package_name___.csproj.tmpl
+++ b/ClientGenerator/src/googleapis/codegen/languages/csharp/default/templates/___package_name___/___package_name___.csproj.tmpl
@@ -13,8 +13,18 @@
     <RepositoryUrl>https://github.com/google/google-api-dotnet-client</RepositoryUrl>
     <PackageIconUrl>https://www.gstatic.com/images/branding/product/1x/google_developers_64dp.png</PackageIconUrl>
     <Description>
+{% noblank %}
+{% if api.module.name in features.clouds %}
+{% for old_api, cloud_api in features.clouds.items %}
+{% if old_api == api.module.name %}
+      This is not the recommended package for working with {% camel_case api.name %}, please use: {{ cloud_api }}
+      This is the deprecated Google APIs Client Library for working with {% camel_case api.name %} {{ api.version }}.
+{% endif %}
+{% endfor %}
+{% else %}
       Google APIs Client Library for working with {% camel_case api.name %} {{ api.version }}.
-
+{% endif %}
+{% endnoblank %}
       Supported Platforms:
       - .NET Framework 4.5+
       - NetStandard1.3, providing .NET Core support.
@@ -24,7 +34,7 @@
       - Windows 8 Apps
       - Windows Phone 8.1
       - Windows Phone Silverlight 8.0
-	  
+
       Incompatible platforms:
       - .NET Framework &lt; 4.0
       - Silverlight

--- a/Src/Generated/Google.Apis.Storage.v1/Google.Apis.Storage.v1.csproj
+++ b/Src/Generated/Google.Apis.Storage.v1/Google.Apis.Storage.v1.csproj
@@ -13,7 +13,8 @@
     <RepositoryUrl>https://github.com/google/google-api-dotnet-client</RepositoryUrl>
     <PackageIconUrl>https://www.gstatic.com/images/branding/product/1x/google_developers_64dp.png</PackageIconUrl>
     <Description>
-      Google APIs Client Library for working with Storage v1.
+      This is not the recommended package for working with Storage, please use: Google.Cloud.Storage.V1
+      This is the deprecated Google APIs Client Library for working with Storage v1.
 
       Supported Platforms:
       - .NET Framework 4.5+
@@ -24,7 +25,7 @@
       - Windows 8 Apps
       - Windows Phone 8.1
       - Windows Phone Silverlight 8.0
-	  
+
       Incompatible platforms:
       - .NET Framework &lt; 4.0
       - Silverlight


### PR DESCRIPTION
This PR includes all GA Cloud packages. We can discuss whether we want to include beta packages in the map for another PR.

One re-generated .csproj (storage) is included in this PR to show what the new package description will look like.

Fixes #1210