### PR TITLE
Remove spurious prefix in doc comments

### DIFF
--- a/Src/Support/Google.Apis.Auth/OAuth2/GoogleCredential.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/GoogleCredential.cs
@@ -179,7 +179,7 @@ namespace Google.Apis.Auth.OAuth2
 
         /// <summary>
         /// <para>Returns <c>true</c> only if this credential type has no scopes by default and requires
-        /// a call to <see cref="o:CreateScoped"/> before use.</para>
+        /// a call to <see cref="CreateScoped(IEnumerable{string})"/> before use.</para>
         ///
         /// <para>Credentials need to have scopes in them before they can be used to access Google services.
         /// Some Credential types have scopes built-in, and some don't. This property indicates whether
@@ -199,7 +199,7 @@ namespace Google.Apis.Auth.OAuth2
         /// <item>
         /// <description>
         /// <see cref="ServiceAccountCredential"/> does not have scopes built-in by default. Caller should
-        /// invoke <see cref="o:CreateScoped"/> to add scopes to the credential.
+        /// invoke <see cref="CreateScoped(IEnumerable{string})"/> to add scopes to the credential.
         /// </description>
         /// </item>
         /// </list>


### PR DESCRIPTION
(This was creating warnings in docfx.)