### PR TITLE
Fix build for legacy targets after upgrade to .NET SDK 2.1

### DIFF
--- a/ClientGenerator/src/googleapis/codegen/languages/csharp/default/templates/___package_name___/___package_name___.csproj.tmpl
+++ b/ClientGenerator/src/googleapis/codegen/languages/csharp/default/templates/___package_name___/___package_name___.csproj.tmpl
@@ -78,12 +78,11 @@
 
   <PropertyGroup Condition="'$(TargetFramework)'=='netstandard1.0'">
     <PackageTargetFallback>portable-net45+win8+wpa81+wp8</PackageTargetFallback>
-    <AutoUnifyAssemblyReferences>false</AutoUnifyAssemblyReferences>
     <AppConfig>app.netstandard10.config</AppConfig>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard1.0'">
-    <PackageReference Include="Google.Apis" Version="[{{ features.pclSupportVersion }}]" />{% if api.authscopes %}
-    <PackageReference Include="Google.Apis.Auth" Version="[{{ features.pclSupportVersion }}]" />{% endif %}
+    <PackageReference Include="Google.Apis" Version="[{{ features.pclSupportVersion }}]" ExcludeAssets="build" />{% if api.authscopes %}
+    <PackageReference Include="Google.Apis.Auth" Version="[{{ features.pclSupportVersion }}]" ExcludeAssets="build" />{% endif %}
     <PackageReference Include="Microsoft.NETCore.Portable.Compatibility" Version="1.0.1" />
   </ItemGroup>
 
@@ -97,8 +96,8 @@
     <AppConfig>app.net40.config</AppConfig>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net40'">
-    <PackageReference Include="Google.Apis" Version="[{{ features.net40SupportVersion }}]" />{% if api.authscopes %}
-    <PackageReference Include="Google.Apis.Auth" Version="[{{ features.net40SupportVersion }}]" />{% endif %}
+    <PackageReference Include="Google.Apis" Version="[{{ features.net40SupportVersion }}]" ExcludeAssets="build" />{% if api.authscopes %}
+    <PackageReference Include="Google.Apis.Auth" Version="[{{ features.net40SupportVersion }}]" ExcludeAssets="build" />{% endif %}
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
.NET SDK 2.1 introduces a problem when depending on packages that contain build tasks built with pre-VS2017 tooling.
This is a work-around which excludes the problematic tasks in legacy targets that are depending on older version of the support libraries.
See https://github.com/Microsoft/msbuild/issues/2111

I don't understand why this has only become an issue with the update to .NET SDK v2.1 from v2.0