### PR TITLE
feat: Support scopes from JSON for Impersonated Credentials

### DIFF
--- a/Src/Support/Google.Apis.Auth/OAuth2/CredentialFactory.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/CredentialFactory.cs
@@ -334,8 +334,9 @@ public static class CredentialFactory
         var maybeTargetPrincipal = ImpersonatedCredential.ExtractTargetPrincipal(parameters.ServiceAccountImpersonationUrl);
         var initializer = new ImpersonatedCredential.Initializer(parameters.ServiceAccountImpersonationUrl, maybeTargetPrincipal)
         {
-            DelegateAccounts = parameters.Delegates?.Length > 0 ? parameters.Delegates.ToList() : null,
+            DelegateAccounts = parameters.Delegates?.Length > 0 ? parameters.Delegates : null,
             QuotaProject = parameters.QuotaProject,
+            Scopes = parameters.Scopes?.Length > 0 ? parameters.Scopes : null,
         };
 
         var impersonatedCredential = ImpersonatedCredential.Create(sourceCredential.ToGoogleCredential(), initializer);

--- a/Src/Support/Google.Apis.Auth/OAuth2/JsonCredentialParameters.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/JsonCredentialParameters.cs
@@ -153,6 +153,12 @@ namespace Google.Apis.Auth.OAuth2
         public string[] Delegates { get; set; }
 
         /// <summary>
+        /// Scopes associated with the impersonated credential.
+        /// </summary>
+        [JsonProperty("scopes")]
+        public string[] Scopes { get; set; }
+
+        /// <summary>
         /// The source credential associated to the impersonated credential.
         /// </summary>
         [JsonProperty("source_credentials")]


### PR DESCRIPTION
When using an impersonated service account, scopes specified in the JSON file were previously ignored.

This change updates the `CredentialFactory` to read the `scopes` array from the impersonated credential configuration. Programmatically set scopes via `CreateScoped` will continue to take precedence over the scopes defined in the JSON file.

[b/450323529](https://b.corp.google.com/450323529)