### PR TITLE
feat: Enable full object checksum validation for multi-chunk resumable uploads

### DIFF
--- a/Src/Support/Google.Apis.Tests/Apis/Upload/ResumableUploadTest.Utilities.cs
+++ b/Src/Support/Google.Apis.Tests/Apis/Upload/ResumableUploadTest.Utilities.cs
@@ -92,5 +92,15 @@ namespace Google.Apis.Tests.Apis.Upload
             internal void WriteLine(string message, [CallerMemberName] string caller = null) =>
                 _outputHelper.WriteLine($"Test {_id:0000} at {DateTime.UtcNow:HH:mm:ss.fff}: {caller} - {message}");
         }
+
+#if NET6_0_OR_GREATER
+        /// <summary>
+        /// Resumable upload class that allows Crc32c to be set for testing.
+        /// </summary>
+        private class TestResumableUploadWithCrc32c
+        {
+            public string Crc32c { get; set; }
+        }
+#endif
     }
 }

--- a/Src/Support/Google.Apis/Google.Apis.csproj
+++ b/Src/Support/Google.Apis/Google.Apis.csproj
@@ -22,6 +22,8 @@ The library supports service requests, media upload and download, etc.
     <ProjectReference Include="..\Google.Apis.Core\Google.Apis.Core.csproj" />
 
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0.1" PrivateAssets="All" />
+
+    <PackageReference Include="System.IO.Hashing" Version="8.0.0" Condition="'$(TargetFramework)' == 'net6.0'" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net462'">


### PR DESCRIPTION
This PR enables full object checksum validation (specifically CRC32C) for JSON-based resumable uploads, ensuring end-to-end data integrity for multi-chunk transfers. Please see [b/461996128](http://b/461996128)