### PR TITLE
chore: Migrate gsutil usage to gcloud storage

### DIFF
--- a/DiscoveryJson/cloudasset.v1.json
+++ b/DiscoveryJson/cloudasset.v1.json
@@ -1836,8 +1836,7 @@
       "id": "GcsDestination",
       "properties": {
         "uri": {
-          "description": "The URI of the Cloud Storage object. It's the same URI that is used by gsutil. Example: \"gs://bucket_name/object_name\". See [Viewing and Editing Object Metadata](https://cloud.google.com/storage/docs/viewing-editing-metadata) for more information. If the specified Cloud Storage object already exists and there is no [hold](https://cloud.google.com/storage/docs/object-holds), it will be overwritten with the exported result.",
-          "type": "string"
+          "description": "The URI of the Cloud Storage object. It's the same URI that is used by gcloud storage. Example: \"gs://bucket_name/object_name\". See [Viewing and Editing Object Metadata](https://cloud.google.com/storage/docs/viewing-editing-metadata) for more information. If the specified Cloud Storage object already exists and there is no [hold](https://cloud.google.com/storage/docs/object-holds), it will be overwritten with the exported result.",          "type": "string"
         },
         "uriPrefix": {
           "description": "The URI prefix of all generated Cloud Storage objects. Example: \"gs://bucket_name/object_name_prefix\". Each object URI is in format: \"gs://bucket_name/object_name_prefix// and only contains assets for that type. starts from 0. Example: \"gs://bucket_name/object_name_prefix/compute.googleapis.com/Disk/0\" is the first shard of output objects containing all compute.googleapis.com/Disk assets. An INVALID_ARGUMENT error will be returned if file with the same name \"gs://bucket_name/object_name_prefix\" already exists.",
@@ -2163,8 +2162,7 @@
       "id": "GoogleCloudAssetV1GcsDestination",
       "properties": {
         "uri": {
-          "description": "Required. The URI of the Cloud Storage object. It's the same URI that is used by gsutil. Example: \"gs://bucket_name/object_name\". See [Viewing and Editing Object Metadata](https://cloud.google.com/storage/docs/viewing-editing-metadata) for more information. If the specified Cloud Storage object already exists and there is no [hold](https://cloud.google.com/storage/docs/object-holds), it will be overwritten with the analysis result.",
-          "type": "string"
+          "description": "Required. The URI of the Cloud Storage object. It's the same URI that is used by gcloud storage. Example: \"gs://bucket_name/object_name\". See [Viewing and Editing Object Metadata](https://cloud.google.com/storage/docs/viewing-editing-metadata) for more information. If the specified Cloud Storage object already exists and there is no [hold](https://cloud.google.com/storage/docs/object-holds), it will be overwritten with the analysis result.",          "type": "string"
         }
       },
       "type": "object"

--- a/DiscoveryJson/containeranalysis.v1.json
+++ b/DiscoveryJson/containeranalysis.v1.json
@@ -4126,8 +4126,7 @@
           ],
           "enumDescriptions": [
             "Unspecified defaults to GSUTIL.",
-            "Use the \"gsutil\" tool to download the source file.",
-            "Use the Cloud Storage Fetcher tool to download the source file."
+            "Use the \"gcloud storage\" tool to download the source file.",            "Use the Cloud Storage Fetcher tool to download the source file."
           ],
           "type": "string"
         }

--- a/DiscoveryJson/toolresults.v1beta3.json
+++ b/DiscoveryJson/toolresults.v1beta3.json
@@ -2022,8 +2022,7 @@
       "id": "FileReference",
       "properties": {
         "fileUri": {
-          "description": "The URI of a file stored in Google Cloud Storage. For example: http://storage.googleapis.com/mybucket/path/to/test.xml or in gsutil format: gs://mybucket/path/to/test.xml with version-specific info, gs://mybucket/path/to/test.xml#1360383693690000 An INVALID_ARGUMENT error will be returned if the URI format is not supported. - In response: always set - In create/update request: always set",
-          "type": "string"
+          "description": "The URI of a file stored in Google Cloud Storage. For example: http://storage.googleapis.com/mybucket/path/to/test.xml or in gcloud storage format: gs://mybucket/path/to/test.xml with version-specific info, gs://mybucket/path/to/test.xml#1360383693690000 An INVALID_ARGUMENT error will be returned if the URI format is not supported. - In response: always set - In create/update request: always set",          "type": "string"
         }
       },
       "type": "object"

--- a/Src/Generated/Google.Apis.CloudAsset.v1beta1/Google.Apis.CloudAsset.v1beta1.cs
+++ b/Src/Generated/Google.Apis.CloudAsset.v1beta1/Google.Apis.CloudAsset.v1beta1.cs
@@ -1490,8 +1490,7 @@ namespace Google.Apis.CloudAsset.v1beta1.Data
     public class GcsDestination : Google.Apis.Requests.IDirectResponseSchema
     {
         /// <summary>
-        /// The URI of the Cloud Storage object. It's the same URI that is used by gsutil. For example:
-        /// "gs://bucket_name/object_name". See [Viewing and Editing Object
+        /// The URI of the Cloud Storage object. It's the same URI that is used by gcloud storage. For example:        /// "gs://bucket_name/object_name". See [Viewing and Editing Object
         /// Metadata](https://cloud.google.com/storage/docs/viewing-editing-metadata) for more information.
         /// </summary>
         [Newtonsoft.Json.JsonPropertyAttribute("uri")]


### PR DESCRIPTION
Automated: Migrate {target_path} from gsutil to gcloud storage

This CL is part of the on going effort to migrate from the legacy `gsutil` tool to the new and improved `gcloud storage` command-line interface.
`gcloud storage` is the recommended and modern tool for interacting with Google Cloud Storage, offering better performance, unified authentication, and a more consistent command structure with other `gcloud` components. 🚀

### Automation Details

This change was **generated automatically** by an agent that targets users of `gsutil`.
The transformations applied are based on the  [gsutil to gcloud storage migration guide](http://go/gsutil-gcloud-storage-migration-guide).

### ⚠️ Action Required: Please Review and Test Carefully

While we have based the automation on the migration guide, every use case is unique.
**It is crucial that you thoroughly test these changes in environments appropriate to your use-case before merging.**  
Be aware of potential differences between `gsutil` and `gcloud storage` that could impact your workflows.  
For instance, the structure of command output may have changed, requiring updates to any scripts that parse it. Similarly, command behavior can differ subtly; the `gcloud storage rsync` command has a different file deletion logic than `gsutil rsync`, which could lead to unintended file deletions.  

Our migration guides can help guide you through a list of mappings and some notable differences between the two tools.

Standard presubmit tests are run as part of this CL's workflow. **If you need to target an additional test workflow or require assistance with testing, please let us know.**

Please verify that all your Cloud Storage operations continue to work as expected to avoid any potential disruptions in production.

### Support and Collaboration

The `GCS CLI` team is here to help! If you encounter any issues, have a complex use case that this automated change doesn't cover, or face any other blockers, please don't hesitate to reach out.
We are happy to work with you to test and adjust these changes as needed.

**Contact:** `gcs-cli-hyd@google.com`

We appreciate your partnership in this important migration effort!

#gsutil-migration
