### PR TITLE
chore: replace old dotnet teams with cloud-sdk-dotnet-team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,4 +5,4 @@
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
 
-* @googleapis/cloud-libraries-dotnet
+* @googleapis/cloud-sdk-dotnet-team

--- a/.github/blunderbuss.yml
+++ b/.github/blunderbuss.yml
@@ -1,2 +1,2 @@
 assign_issues:
-  - googleapis/cloud-libraries-dotnet
+  - googleapis/cloud-sdk-dotnet-team


### PR DESCRIPTION
b/479544839