### PR TITLE
chore: Update version 1.73.0 -> 1.74.0

### DIFF
--- a/Src/Support/CommonProjectProperties.xml
+++ b/Src/Support/CommonProjectProperties.xml
@@ -2,7 +2,7 @@
 
   <!-- common nupkg information -->
   <PropertyGroup>
-    <Version>1.73.0</Version>
+    <Version>1.74.0</Version>
     <Authors>Google LLC</Authors>
     <Copyright>Copyright 2021 Google LLC</Copyright>
     <PackageTags>Google</PackageTags>

--- a/features.json
+++ b/features.json
@@ -2,10 +2,10 @@
   "language": "csharp",
   "description": "C# libraries for Google APIs.",
   // Version of the generated packages
-  "releaseVersion": "1.73.0",
+  "releaseVersion": "1.74.0",
   
   // Version of the support libraries upon which to depend.
-  "currentSupportVersion": "1.73.0",
+  "currentSupportVersion": "1.74.0",
 
   // Defines the map of Google.Cloud packages that supercede Google.Apis packages
   "cloudPackageMap": {


### PR DESCRIPTION
Bug fixes:

  - #3156 Use a single instance of the default serializer.
  - #3151 Do not duplicate quota project header on retries.

Features:

  - #3091 Expose helper methots to build a credential from `JsonParameters`.