### PR TITLE
fix(auth): reject user credentials lacking refresh token under ADC

### DIFF
--- a/Src/Support/Google.Apis.Auth.Tests/OAuth2/DefaultCredentialProviderTests.cs
+++ b/Src/Support/Google.Apis.Auth.Tests/OAuth2/DefaultCredentialProviderTests.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 Copyright 2015 Google Inc
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -83,6 +83,9 @@ namespace Google.Apis.Auth.Tests.OAuth2
         private const string ImpersonatedServiceAccountCredentialUniverseDomainDifferentFileName = "impersonated_service_account_credential_universe_domain_different.json";
         private const string RecursiveImpersonatedServiceAccountCredentialFileName = "recursive_impersonated_service_account_credential.json";
         private const string ExternalAccountAuthorizedUserCredentialFileName = "external_account_authorized_user_credential.json";
+        private const string IdTokenCredentialFileName = "id_token_credential.json";
+        private const string SignerCredentialFileName = "signer_credential.json";
+        private const string UserCredentialNoRefreshTokenFileName = "user_credential_no_refresh_token.json";
 
         public DefaultCredentialProviderTests()
         {
@@ -426,6 +429,18 @@ namespace Google.Apis.Auth.Tests.OAuth2
         public async Task GetDefaultCredential_InvalidCredentialFile(string brokenCredentialFileName)
         {
             credentialProvider.SetEnvironmentVariable(CredentialEnvironmentVariable, brokenCredentialFileName);
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(credentialProvider.GetDefaultCredentialAsync);
+            Assert.Contains("Error reading credential file from location", exception.Message);
+        }
+
+        /// <summary>Credential file has unsupported credential types.</summary>
+        [Theory]
+        [InlineData(IdTokenCredentialFileName)]
+        [InlineData(SignerCredentialFileName)]
+        [InlineData(UserCredentialNoRefreshTokenFileName)]
+        public async Task GetDefaultCredential_UnsupportedCredentialType(string unsupportedCredentialFileName)
+        {
+            credentialProvider.SetEnvironmentVariable(CredentialEnvironmentVariable, unsupportedCredentialFileName);
             var exception = await Assert.ThrowsAsync<InvalidOperationException>(credentialProvider.GetDefaultCredentialAsync);
             Assert.Contains("Error reading credential file from location", exception.Message);
         }

--- a/Src/Support/Google.Apis.Auth.Tests/OAuth2/FakeCredentialFiles/id_token_credential.json
+++ b/Src/Support/Google.Apis.Auth.Tests/OAuth2/FakeCredentialFiles/id_token_credential.json
@@ -1,0 +1,3 @@
+{
+  "type": "id_token"
+}

--- a/Src/Support/Google.Apis.Auth.Tests/OAuth2/FakeCredentialFiles/signer_credential.json
+++ b/Src/Support/Google.Apis.Auth.Tests/OAuth2/FakeCredentialFiles/signer_credential.json
@@ -1,0 +1,3 @@
+{
+  "type": "signer"
+}

--- a/Src/Support/Google.Apis.Auth.Tests/OAuth2/FakeCredentialFiles/user_credential_no_refresh_token.json
+++ b/Src/Support/Google.Apis.Auth.Tests/OAuth2/FakeCredentialFiles/user_credential_no_refresh_token.json
@@ -1,0 +1,5 @@
+{
+  "client_id": "CLIENT_ID",
+  "client_secret": "CLIENT_SECRET",
+  "type": "authorized_user"
+}

--- a/Src/Support/Google.Apis.Auth/OAuth2/CredentialFactory.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/CredentialFactory.cs
@@ -292,7 +292,8 @@ public static class CredentialFactory
     {
         if (credentialParameters.Type != JsonCredentialParameters.AuthorizedUserCredentialType ||
             string.IsNullOrEmpty(credentialParameters.ClientId) ||
-            string.IsNullOrEmpty(credentialParameters.ClientSecret))
+            string.IsNullOrEmpty(credentialParameters.ClientSecret) ||
+            string.IsNullOrEmpty(credentialParameters.RefreshToken))
         {
             throw new InvalidOperationException("JSON data does not represent a valid user credential.");
         }


### PR DESCRIPTION
The .NET auth library was missing validation for user credentials (authorized_user) when loaded via Application Default Credentials (ADC). Unlike the Java and Python libraries, which explicitly require refresh_token, client_id, and client_secret to be present, this library previously accepted authorized_user credentials without a refresh_token, failing later when token refresh was attempted.

This change ensures that user credentials require a non-empty refresh_token when loading under ADC, throwing an exception during initialization if missing. It also adds unit tests verifying that unsupported credential types (such as id_token, signer, or authorized_user without a refresh token) are explicitly rejected.