### PR TITLE
test(auth): verify refresh token preservation when omitted in server response

### DIFF
--- a/Src/Support/Google.Apis.Auth.Tests/OAuth2/Flows/AuthorizationCodeFlowTests.cs
+++ b/Src/Support/Google.Apis.Auth.Tests/OAuth2/Flows/AuthorizationCodeFlowTests.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 Copyright 2013 Google Inc
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -284,6 +284,29 @@ namespace Google.Apis.Auth.Tests.OAuth2.Flows
             Assert.Equal("uSer", store.StoredKey);
         }
 
+        [Fact]
+        public async Task TestRefreshTokenAsync_OmitRefreshToken()
+        {
+            var store = new FakeDataStore();
+            var handler = new FetchTokenMessageHandler();
+            handler.OmitRefreshToken = true;
+            handler.RefreshTokenRequest = new RefreshTokenRequest()
+            {
+                RefreshToken = "REFRESH",
+                Scope = "a"
+            };
+            MockHttpClientFactory mockFactory = new MockHttpClientFactory(handler);
+            var flow = CreateFlow(httpClientFactory: mockFactory, scopes: new[] { "a" }, dataStore: store);
+            var response = await flow.RefreshTokenAsync("uSer", "REFRESH", default);
+            
+            Assert.Equal("a", response.AccessToken);
+            Assert.Equal("REFRESH", response.RefreshToken); // Preserved
+            Assert.Equal(100, response.ExpiresInSeconds);
+            Assert.Equal("b", response.Scope);
+
+            Assert.Equal("uSer", store.StoredKey);
+        }
+
         #region FetchToken
 
         /// <summary>
@@ -296,6 +319,7 @@ namespace Google.Apis.Auth.Tests.OAuth2.Flows
             internal AuthorizationCodeTokenRequest AuthorizationCodeTokenRequest { get; set; }
             internal RefreshTokenRequest RefreshTokenRequest { get; set; }
             internal bool Error { get; set; }
+            internal bool OmitRefreshToken { get; set; }
 
             protected override async Task<HttpResponseMessage> SendAsyncCore(HttpRequestMessage request,
                 CancellationToken taskCancellationToken)
@@ -381,7 +405,7 @@ namespace Google.Apis.Auth.Tests.OAuth2.Flows
                     var serializedObject = NewtonsoftJsonSerializer.Instance.Serialize(new TokenResponse
                     {
                         AccessToken = "a",
-                        RefreshToken = "r",
+                        RefreshToken = OmitRefreshToken ? null : "r",
                         ExpiresInSeconds = 100,
                         Scope = "b",
                     });

--- a/Src/Support/Google.Apis.Auth.Tests/OAuth2/UserCredentialTests.cs
+++ b/Src/Support/Google.Apis.Auth.Tests/OAuth2/UserCredentialTests.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 Copyright 2023 Google Inc
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -64,6 +64,22 @@ public class UserCredentialTests
         Assert.Throws<InvalidOperationException>(() => credential.WithUniverseDomain("universeDomain"));
     }
 
+    [Fact]
+    public async Task RefreshToken_OmittedInResponse_Preserved()
+    {
+        var flow = new MockAuthorizationCodeFlow();
+        var initialToken = new TokenResponse { AccessToken = "access_token_1", RefreshToken = "refresh_token_1" };
+        var credential = new UserCredential(flow, "userId", initialToken);
+
+        flow.TokenResponse = new TokenResponse { AccessToken = "access_token_2", RefreshToken = null };
+
+        bool refreshed = await credential.RefreshTokenAsync(default);
+
+        Assert.True(refreshed);
+        Assert.Equal("access_token_2", credential.Token.AccessToken);
+        Assert.Equal("refresh_token_1", credential.Token.RefreshToken); // Preserved
+    }
+
     private class FakeAuthorizationCodeFlow : IAuthorizationCodeFlow
     {
         public static readonly FakeAuthorizationCodeFlow Default = new FakeAuthorizationCodeFlow();
@@ -88,6 +104,23 @@ public class UserCredentialTests
 
         public Task RevokeTokenAsync(string userId, string token, CancellationToken taskCancellationToken) => throw new NotImplementedException();
 
+        public bool ShouldForceTokenRetrieval() => throw new NotImplementedException();
+    }
+
+    private class MockAuthorizationCodeFlow : IAuthorizationCodeFlow
+    {
+        public TokenResponse TokenResponse { get; set; }
+
+        public IAccessMethod AccessMethod => throw new NotImplementedException();
+        public IClock Clock => SystemClock.Default;
+        public IDataStore DataStore => throw new NotImplementedException();
+        public AuthorizationCodeRequestUrl CreateAuthorizationCodeRequest(string redirectUri) => throw new NotImplementedException();
+        public Task DeleteTokenAsync(string userId, CancellationToken taskCancellationToken) => throw new NotImplementedException();
+        public void Dispose() {}
+        public Task<TokenResponse> ExchangeCodeForTokenAsync(string userId, string code, string redirectUri, CancellationToken taskCancellationToken) => throw new NotImplementedException();
+        public Task<TokenResponse> LoadTokenAsync(string userId, CancellationToken taskCancellationToken) => throw new NotImplementedException();
+        public Task<TokenResponse> RefreshTokenAsync(string userId, string refreshToken, CancellationToken taskCancellationToken) => Task.FromResult(TokenResponse);
+        public Task RevokeTokenAsync(string userId, string token, CancellationToken taskCancellationToken) => throw new NotImplementedException();
         public bool ShouldForceTokenRetrieval() => throw new NotImplementedException();
     }
 }


### PR DESCRIPTION
This change adds test coverage verifying that during token refresh, if the server's TokenResponse does not return a refresh_token, the client library preserves the pre-existing refresh token stored in the credential and authorization flow object instead of overwriting it with null/empty.

Tests are added to:
- AuthorizationCodeFlowTests: Verifies AuthorizationCodeFlow preserves the refresh token when fetching a new token response.
- UserCredentialTests: Verifies UserCredential preserves the refresh token in its token state during refresh.