### PR TITLE
tests: Fix flake in `RequestParameterDescriptorProviderTest`.

### DIFF
--- a/Src/Support/Google.Apis.Core/ApplicationContext.cs
+++ b/Src/Support/Google.Apis.Core/ApplicationContext.cs
@@ -17,7 +17,6 @@ limitations under the License.
 using Google.Apis.Logging;
 using Google.Apis.Util;
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
 

--- a/Src/Support/Google.Apis.Tests/Apis/Utils/RequestParameterDescriptorProviderTest.cs
+++ b/Src/Support/Google.Apis.Tests/Apis/Utils/RequestParameterDescriptorProviderTest.cs
@@ -23,9 +23,12 @@ using Xunit;
 
 namespace Google.Apis.Tests.Apis.Utils
 {
-    /// <summary>Tests for <see cref="Google.Apis.Util.RequestParameterDescriptorProvider"/>.</summary>
+    /// <summary>Tests for <see cref="RequestParameterDescriptorProvider"/>.</summary>
+    [Collection(ParamDescriptorCacheSequential)]
     public class RequestParameterDescriptorProviderTest
     {
+        internal const string ParamDescriptorCacheSequential = "RequestParameterDescriptorProvider Sequential Collection";
+
         internal class TestClass
         {
             [RequestParameter("test_param", RequestParameterType.Query)]

--- a/Src/Support/Google.Apis.Tests/ApplicationContextTests.cs
+++ b/Src/Support/Google.Apis.Tests/ApplicationContextTests.cs
@@ -22,7 +22,8 @@ using Xunit;
 
 namespace Google.Apis.Tests
 {
-    /// <summary>Tests for <see cref="Google.ApplicationContext"/>.</summary>
+    /// <summary>Tests for <see cref="ApplicationContext"/>.</summary>
+    [Collection(RequestParameterDescriptorProviderTest.ParamDescriptorCacheSequential)]
     public class ApplicationContextTests
     {
         // A mock logger that is identical to the NullLogger,


### PR DESCRIPTION
Because these tests rely on the static parameter descriptor cache, we cannot run them in parallel with other tests that may reset the cache. We put all of these tests on the same collection.